### PR TITLE
Update aps-impl.scala: null checking before equality test

### DIFF
--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -91,7 +91,7 @@ class I_TYPE[T](name : String) extends Module(name) with C_TYPE[T] {
       case t:Value => assert(t.myType == this)
     };
   def f_equal(x : T_Result, y : T_Result) : Boolean = f_node_equivalent(x,y);
-  def f_node_equivalent(x : T_Result, y : T_Result) : Boolean = x != null && x.equals(y);
+  def f_node_equivalent(x : T_Result, y : T_Result) : Boolean = x != null && y != null && x.equals(y);
   def f_string(x : T_Result) : String = x.toString();
 }
     

--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -482,7 +482,7 @@ trait CircularEvaluation[V_P, V_T] extends Evaluation[V_P,V_T] {
   }
 
   private def check(newValue : ValueType) : Unit = {
-    if (!(value == null && newValue == null) && !lattice.v_equal(value,newValue)) {
+    if (!lattice.v_equal(value,newValue)) {
       inCycle.helper.modified = true;
       if (!lattice.v_compare(value,newValue)) {
 	throw new CyclicAttributeException("non-monotonic " + name);

--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -482,7 +482,7 @@ trait CircularEvaluation[V_P, V_T] extends Evaluation[V_P,V_T] {
   }
 
   private def check(newValue : ValueType) : Unit = {
-    if (!lattice.v_equal(value,newValue)) {
+    if (!(value == null && newValue == null) && !lattice.v_equal(value,newValue)) {
       inCycle.helper.modified = true;
       if (!lattice.v_compare(value,newValue)) {
 	throw new CyclicAttributeException("non-monotonic " + name);

--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -91,7 +91,7 @@ class I_TYPE[T](name : String) extends Module(name) with C_TYPE[T] {
       case t:Value => assert(t.myType == this)
     };
   def f_equal(x : T_Result, y : T_Result) : Boolean = f_node_equivalent(x,y);
-  def f_node_equivalent(x : T_Result, y : T_Result) : Boolean = x.equals(y);
+  def f_node_equivalent(x : T_Result, y : T_Result) : Boolean = x != null && x.equals(y);
   def f_string(x : T_Result) : String = x.toString();
 }
     


### PR DESCRIPTION
Stacktrace:
```
java.lang.NullPointerException
	at I_TYPE.f_node_equivalent(aps-impl.scala:94)
	at I_TYPE.f_equal(aps-impl.scala:93)
	at I_TYPE$$anonfun$2.apply(aps-impl.scala:85)
	at I_TYPE$$anonfun$2.apply(aps-impl.scala:85)
	at CircularEvaluation$class.check(aps-impl.scala:485)
	at CircularEvaluation$class.set(aps-impl.scala:494)
	at M_SEMANT$E_children.set(turingol-impl.scala:58)
	at Attribute.set(aps-impl.scala:325)
	at Attribute.assign(aps-impl.scala:292)
	at M_SEMANT.visit_0_1_0(turingol-impl.scala:74)
	at M_SEMANT.visit_0_1(turingol-impl.scala:68)
	at M_SEMANT$$anonfun$visit$1.apply(turingol-impl.scala:93)
	at M_SEMANT$$anonfun$visit$1.apply(turingol-impl.scala:92)
	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
	at M_SEMANT.visit(turingol-impl.scala:92)
	at M_SEMANT.finish(turingol-impl.scala:99)
	at TuringolCompiler$.main(turingol-driver.scala:50)
	at TuringolCompiler.main(turingol-driver.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at scala.reflect.internal.util.ScalaClassLoader$$anonfun$run$1.apply(ScalaClassLoader.scala:70)
	at scala.reflect.internal.util.ScalaClassLoader$class.asContext(ScalaClassLoader.scala:31)
	at scala.reflect.internal.util.ScalaClassLoader$URLClassLoader.asContext(ScalaClassLoader.scala:101)
	at scala.reflect.internal.util.ScalaClassLoader$class.run(ScalaClassLoader.scala:70)
	at scala.reflect.internal.util.ScalaClassLoader$URLClassLoader.run(ScalaClassLoader.scala:101)
	at scala.tools.nsc.CommonRunner$class.run(ObjectRunner.scala:22)
	at scala.tools.nsc.ObjectRunner$.run(ObjectRunner.scala:39)
	at scala.tools.nsc.CommonRunner$class.runAndCatch(ObjectRunner.scala:29)
	at scala.tools.nsc.ObjectRunner$.runAndCatch(ObjectRunner.scala:39)
	at scala.tools.nsc.MainGenericRunner.runTarget$1(MainGenericRunner.scala:65)
	at scala.tools.nsc.MainGenericRunner.run$1(MainGenericRunner.scala:87)
	at scala.tools.nsc.MainGenericRunner.process(MainGenericRunner.scala:98)
	at scala.tools.nsc.MainGenericRunner$.main(MainGenericRunner.scala:103)
	at scala.tools.nsc.MainGenericRunner.main(MainGenericRunner.scala)
```