### PR TITLE
Fixed issue-7 fix code generation of multiple addition to collection

### DIFF
--- a/analyze/aps-info.h
+++ b/analyze/aps-info.h
@@ -135,6 +135,7 @@ struct Expression_info {
 #define EXPR_LHS_FLAG 1
 #define EXPR_RHS_FLAG 2
 	int	 index;			// represent the nodes of Qe and Qe(-).
+  Expression collect_next;
 };
 extern struct Expression_info *Expression_info(Expression);
 #define EXPR_NEXT(expr) (Expression_info(expr)->next_expr)

--- a/aps2scala/static-impl.cc
+++ b/aps2scala/static-impl.cc
@@ -83,12 +83,9 @@ Expression* make_instance_assignment(AUG_GRAPH* aug_graph,
         if (in->index >= n) fatal_error("bad index for instance");
 
         if (array[in->index] != NULL) {
-          Expression ptr = array[in->index];
-          Expression last = ptr;
-
-          while ((ptr = Expression_info(ptr)->collect_next) != NULL) last = ptr;
-
-          Expression_info(last)->collect_next = assign_rhs(d);
+          Expression new_expr = assign_rhs(d);
+          Expression_info(new_expr)->collect_next = array[in->index];
+          array[in->index] = new_expr;
         } else {
           array[in->index] = assign_rhs(d);
         }

--- a/aps2scala/static-impl.cc
+++ b/aps2scala/static-impl.cc
@@ -83,9 +83,12 @@ Expression* make_instance_assignment(AUG_GRAPH* aug_graph,
         if (in->index >= n) fatal_error("bad index for instance");
 
         if (array[in->index] != NULL) {
-          Expression prev = array[in->index];
-          array[in->index] = assign_rhs(d);
-          Expression_info(array[in->index])->collect_next = prev;
+          Expression ptr = array[in->index];
+          Expression last = ptr;
+
+          while ((ptr = Expression_info(ptr)->collect_next) != NULL) last = ptr;
+
+          Expression_info(last)->collect_next = assign_rhs(d);
         } else {
           array[in->index] = assign_rhs(d);
         }
@@ -382,7 +385,7 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
     cout << "Problem assigning " << in << endl;
     os << "// Not sure what to do for " << in << endl;
 
-  } while ((rhs = Expression_info(rhs)->collect_next) != NULL);
+  } while (rhs != NULL && (rhs = Expression_info(rhs)->collect_next) != NULL);
   }
   return 0; // no more!
 }


### PR DESCRIPTION
Working solution that fixes the issue with aps2scala's code generation. The trick I used is to add another property to ExpressionInfo so I can create a LinkedList of expressions and then run the code generation for all LinkedList items.

Proof:
https://www.diffchecker.com/4mhhSGzT

```
with "tiny";

module TINY_IMPL[T :: var TINY[]] extends T
begin

  type Integers := BAG[Integer];
  var collection leaves : Integers := { };

  type EntityRef := remote Wood;
  type Entities := BAG[EntityRef];
  collection attribute Wood.amir : Entities;

  pragma synthesized(amir);

  match ?l=leaf(?x) begin

    leaves :> { 20 };
    leaves :> { 10 };
    leaves :> { 0 };
    l.amir :> { l };
  end;

  match ?b=branch(?x,?y) begin
     leaves :> { 30 };
  end;

  match ?p=root(?b) begin
  end;
end;

```