### PR TITLE
Test cycle example, minor clean up

### DIFF
--- a/examples/scala/Makefile
+++ b/examples/scala/Makefile
@@ -52,7 +52,7 @@ TestUseCollDriver.class : test_use_coll_implicit.class test-use-coll-driver.scal
 test_cycle_implicit.class : test-cycle.scala
 	${SCALAC} ${SCALACFLAGS} $<
 
-TestCycleDriver.class : test_cycle_implicit.class test-cycle-driver.scala
+TestCycleDriver.class : tiny_implicit.class test_cycle_implicit.class test-cycle-driver.scala
 	${SCALAC} ${SCALACFLAGS}  test-cycle-driver.scala
 
 TinyParser.class : tiny-parser.handcode.scala tiny_implicit.class

--- a/examples/scala/test-cycle-driver.scala
+++ b/examples/scala/test-cycle-driver.scala
@@ -1,6 +1,6 @@
 object TestCycleDriver extends App
 {
-    val m = new M_TEST_CYCLE("Tiny");
+    val m = new M_TINY("Tiny");
     type T_Tiny = m.T_Result;
     val t_Tiny = m.t_Result;
 
@@ -10,5 +10,8 @@ object TestCycleDriver extends App
 
     m.finish();
 
-    println("leaves is " + t_Tiny.v_leaves);
+    val m2 = new M_TEST_CYCLE("Test Cycle",m);
+    val w2 = w.asInstanceOf[m2.T_Wood];
+
+    println("leaves is " + m2.v_leaves);
 }

--- a/examples/test-cycle.aps
+++ b/examples/test-cycle.aps
@@ -1,14 +1,14 @@
-module TEST_CYCLE[] begin
-  phylum Wood;
-  
-  constructor branch(x,y : Wood) : Wood;
-  constructor leaf(x : Integer) : Wood;
-  
+with "tiny";
+
+module TEST_CYCLE[T :: var TINY[]] extends T
+begin  
   type Integers := SET[Integer];
   type IntegerLattice := UNION_LATTICE[Integer,Integers];
 
   var circular collection leaves : IntegerLattice;
   circular attribute Wood.partial : IntegerLattice;
+
+  pragma synthesized(leaves,partial);
 
   match ?l=leaf(?x) begin
     l.partial := (leaves \ x) \/ {x+1} ;


### PR DESCRIPTION
After these changes to `test-cycle.aps` we can now run it with `make test-cycle.sched`