### PR TITLE
Issue 18: in progress, not finished

### DIFF
--- a/analyze/aps-bind.c
+++ b/analyze/aps-bind.c
@@ -624,6 +624,9 @@ static void *do_bind(void *vscope, void *node) {
       SCOPE new_scope = scope;
       Expression e = (Expression)node;
       switch (Expression_KEY(e)) {
+      case KEYtype_value:
+        bind_Use(type_use_use(type_value_t(e)),NAME_VALUE,scope);
+        break;
       case KEYvalue_use:
 	bind_Use(value_use_use(e),NAME_VALUE,scope);
 	break;

--- a/analyze/aps-fiber.c
+++ b/analyze/aps-fiber.c
@@ -327,6 +327,8 @@ Expression field_ref_object(Expression expr) {
 }
 
 BOOL local_type_p(Type ty) { /* could this type carry an object? */
+  if (ty == NULL) return FALSE;
+
   switch (Type_KEY(ty)) {
   default:
     return TRUE;
@@ -1492,6 +1494,8 @@ static int recursion_level = 0;
 
 // calculating USET of e given oset.
 USET doUO(Expression e, OSET oset) {
+  if (infer_expr_type(e) == NULL) return EMPTY_OSET;
+
   if (!local_type_p(infer_expr_type(e))) oset = EMPTY_OSET;
   ENTER;
 //  printf("%d: doUO starting on line %d.\n", recursion_level,
@@ -1621,6 +1625,8 @@ int same_field(Expression e1, Expression e2) {
 // get Oset of e given a uset.
 OSET doOU(Expression e, USET uset)
 {
+  if (infer_expr_type(e) == NULL) return EMPTY_OSET;
+
   if (!local_type_p(infer_expr_type(e))) uset = EMPTY_USET;
   ENTER;
 //  printf("%d: doOU starting on line %d.\n", recursion_level, tnode_line_number(e));

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -27,7 +27,7 @@ Type constructor_return_type(Declaration decl) {
   return rt;
 }
 
-Declaration resolve_module_from_type_environment(TypeEnvironment type_env) {
+Declaration module_from_type_environment(TypeEnvironment type_env) {
   Declaration module = NULL;
 
   while (type_env != NULL) {
@@ -72,15 +72,8 @@ static void* do_typechecking(void* ignore, void*node) {
     {
       Declaration decl = (Declaration)node;
 
-      declaration_def(decl)
-
       if (DECL_IS_START_PHYLUM(decl)) {
         if (root_phylum == NULL) {
-          Def_info(NULL)->
-          phylum_decl_type(decl)
-          if (Declaration_KEY(decl) == KEYphylum_decl && resolve_module_from_type_environment(Use_info(type_use_use(phylum_decl_type(decl)))->use_type_env) != current_module) {
-            aps_error(decl, "root_phylum should be called in the same module as phylum itself");
-          }
           root_phylum = decl;
         } else {
           aps_error(decl, "root_phylum cannot be set more than one time");
@@ -88,6 +81,35 @@ static void* do_typechecking(void* ignore, void*node) {
       }
 
       switch (Declaration_KEY(decl)) {
+        case KEYpragma_call:
+        {
+          Symbol pragma_symb = pragma_call_name(decl);
+          if (pragma_symb == intern_symbol("root_phylum")) {
+            Expression pragma_arg = first_Expression(pragma_call_parameters(decl));
+
+            switch (Expression_KEY(pragma_arg))
+            {
+              case KEYtype_value:
+              {
+                switch (Type_KEY(type_value_T(pragma_arg)))
+                {
+                  case KEYtype_use:
+                    // TODO: TypeEnvironment is NULL, why?
+                    if (module_from_type_environment(USE_TYPE_ENV(type_use_use(type_value_t(pragma_arg)))) != current_module) {
+                      aps_error(decl, "root_phylum should be called in the same module as phylum itself");
+                    }
+                    break;
+                  default:
+                    break;
+                  }
+              }
+              default:
+                break;
+            }
+          }
+          break;
+        }
+
         case KEYmodule_decl:
           current_module = (Declaration) node;
           break;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -27,7 +27,26 @@ Type constructor_return_type(Declaration decl) {
   return rt;
 }
 
+Declaration resolve_module_from_type_environment(TypeEnvironment type_env) {
+  Declaration module = NULL;
+
+  while (type_env != NULL) {
+    switch (Declaration_KEY(type_env->source))
+    {
+      case KEYmodule_decl:
+        module = type_env->source;
+        break;
+      default:
+        break;
+    }
+    type_env = type_env->outer;
+  }
+
+  return module;
+}
+
 Declaration current_module = NULL;
+Declaration root_phylum = NULL;
 
 static void* do_typechecking(void* ignore, void*node) {
   // find places where Expression, Pattern or Default is used
@@ -52,6 +71,22 @@ static void* do_typechecking(void* ignore, void*node) {
   case KEYDeclaration:
     {
       Declaration decl = (Declaration)node;
+
+      declaration_def(decl)
+
+      if (DECL_IS_START_PHYLUM(decl)) {
+        if (root_phylum == NULL) {
+          Def_info(NULL)->
+          phylum_decl_type(decl)
+          if (Declaration_KEY(decl) == KEYphylum_decl && resolve_module_from_type_environment(Use_info(type_use_use(phylum_decl_type(decl)))->use_type_env) != current_module) {
+            aps_error(decl, "root_phylum should be called in the same module as phylum itself");
+          }
+          root_phylum = decl;
+        } else {
+          aps_error(decl, "root_phylum cannot be set more than one time");
+        }
+      }
+
       switch (Declaration_KEY(decl)) {
         case KEYmodule_decl:
           current_module = (Declaration) node;


### PR DESCRIPTION
The program now does not crash if `root_phylum` is defined for a second time after changing `aps-fiber.c`. However, it will be caught as a type error in `aps-type.c`.

I was trying to add a condition where phylum declaration and `root_phylum` pragma call are all defined under the same module. But I'm failing because `UseInfo(type_use_use(type_value_t(pragma_arg)))->type_env` is null but `UseInfo(type_use_use(type_value_t(pragma_arg)))` is not null.

I think the type environment for `KEYtype_use` is not set in `aps-bind.c`.

**Update as of 10/14**
After some investigation in `aps-bind.c`'s `bind_Use_by_name` method I see `TypeEnvironment` (`scope->type_env`) is null and when we call `instantiate_type_env(NULL)` it returns null. I'm not sure how to get a type contour. Trying to change the code to say root phylum's  `TypeEnvironment` is not null and maybe is set to the module declaration it belongs to causes further errors.