### PR TITLE
Avoid calling decl_name on assignment

### DIFF
--- a/analyze/aps-fiber.c
+++ b/analyze/aps-fiber.c
@@ -1792,6 +1792,11 @@ void *print_all_ou(void *statep, void *node) {
   switch (ABSTRACT_APS_tnode_phylum(node)) {
   case KEYDeclaration: {
     Declaration decl = (Declaration)node;
+    switch (Declaration_KEY(decl))
+    {
+      case KEYassign:
+        return;
+    }
     if (Declaration_info(decl)->oset != NULL) {
       printf("OSET of node: %s\n", decl_name(decl));
       print_oset(Declaration_info(decl)->oset);
@@ -1852,8 +1857,15 @@ int id_decl_node(Declaration decl) {
   FSA_next_node_index += 2;
 
   if (fiber_debug & ALL_FIBERSETS) {
+    switch (Declaration_KEY(decl))
+    {
+      case KEYassign:
+        break;
+      default:
     printf("%d: index for %s is %d\n",tnode_line_number(decl),
 	   decl_name(decl),index);
+        break;
+    }
   }
   Declaration_info(decl)->index = index;
   omega = add_to_nodeset(omega, index);


### PR DESCRIPTION
Exception:

```
>> ../bin/apssched -DeFEfpa -p .:../base tiny-circular
fatal error: declaration_def: called with normal_assign
```

Backtrace 1:
```
(gdb) backtrace
#0  declaration_def (_node=0x555555d7ed80) at aps-util.c:113
#1  0x00005555555609b8 in print_all_ou (statep=0x555555d87f50, node=0x555555d7ed80) at aps-fiber.c:1796
#2  0x0000555555584300 in traverse_Declaration (func=0x555555560967 <print_all_ou>, arg=0x555555d87f50, _node=0x555555d7ed80)
    at aps-traverse.c:284
```
Backtrace 2:
```
gdb) backtrace
#0  declaration_def (_node=0x555555d7ed80) at aps-util.c:113
#1  0x0000555555560bd0 in id_decl_node (decl=0x555555d7ed80) at aps-fiber.c:1862
#2  0x0000555555560ef9 in count_node (u=0x555555d87f50, node=0x555555d7ed80) at aps-fiber.c:1938
```

APS program:
```
with "basic";
with "tiny";

module TINY_CIRCULAR[T :: var TINY[]] extends T
begin

    phylum S;
    type RemoteS := remote S;
    type Integers := SET[Integer];
    type IntegerLattice := UNION_LATTICE[Integer, Integers];

    circular collection attribute S.s_bag1 : IntegerLattice := {};
    circular collection attribute S.s_bag2 : IntegerLattice := {};

    attribute Root.result : Integers;

    attribute Wood.w_s : RemoteS;
        
    pragma synthesized(w_s, result);
    pragma inherited();

    constructor s_constructor() : S;

    match ?l=leaf(?x) begin
        t : S := s_constructor();
        t.s_bag1 :> { x };
        l.w_s := t;
    end;

    match ?b=branch(?x,?y) begin
        v : S := s_constructor();
        b.w_s := v;
        v.s_bag1 :> x.w_s.s_bag1 \/ y.w_s.s_bag1 \/ v.s_bag2;
    end;

    match ?p=root(?b) begin
        b.w_s.s_bag2 :> b.w_s.s_bag1 \/ { 1, 2, 3 };
        p.result := b.w_s.s_bag1;
    end;
end;

```
