### PR TITLE
clang: non-void function should return a value

### DIFF
--- a/analyze/aps-fiber.c
+++ b/analyze/aps-fiber.c
@@ -1795,7 +1795,7 @@ void *print_all_ou(void *statep, void *node) {
     switch (Declaration_KEY(decl))
     {
       case KEYassign:
-        return;
+        return statep;
     }
     if (Declaration_info(decl)->oset != NULL) {
       printf("OSET of node: %s\n", decl_name(decl));


### PR DESCRIPTION
Different behavior while compiling on GNU and Clang.

On GNU gcc: 
warning: ‘return’ with no value, in function returning non-void

On Clang gcc:
error: non-void function 'print_all_ou' should return a 
value