### PR TITLE
Debugging improvement

### DIFF
--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -1976,7 +1976,7 @@ static void init_analysis_state(STATE *s, Declaration module) {
     }
     { int phyla_count = 0;
       if (edecls == NULL) {
-	aps_error(module,"no extension to module %s",
+	fatal_error("no extension to module %s",
 		  symbol_name(def_name(declaration_def(module))));
       } else {
 	Declaration edecl = first_Declaration(edecls);

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,13 @@
+APSSCHED=../bin/apssched
+BASE=.:../base
+
 default:
 	@echo "Try 'make simple-oag.sched' to schedule AG in simple-oag"
 
 %.sched : %.aps
-	../bin/apssched -DCOT -p .:../base $*
+	${APSSCHED} -DCOT -p ${BASE} $*
+
+%.debug: %.aps
+	gdb --args "${APSSCHED}" "-DeFEfpa" "-p" "${BASE}" "$*"
 
 .PHONY: default %.sched


### PR DESCRIPTION
1) when extended module is missing, it is a fatal error not a warning.
For example scheduling `tiny.sched` was resulting in cascading error because:
   - APS always looks for root_phylum (or `START_PHYLUM_FLAG` declaration flag) in extended module so even specifying root_phylum in base module is no good.
   - APS fails to find matches for tree nodes hence `aps-fiber.c` will fail and throws: `cannot get shared_info for null phylum`

2) Added .debug option for gdb debugging. So now we can say `make tiny.debug`