### PR TITLE
Working attempt to fix type problem for lattices

### DIFF
--- a/aps2scala/dump-scala.cc
+++ b/aps2scala/dump-scala.cc
@@ -858,6 +858,7 @@ void dump_some_class_decl(Declaration decl, ostream& oss)
   for (Declaration d=first_Declaration(body); d; d=DECL_NEXT(d)) {
     const char *n = decl_code_name(d);
     bool is_phylum = false;
+    bool is_lattice = strstr(n, "Lattice") ? 1 : 0;
     switch (Declaration_KEY(d)) {
     default:
       aps_warning(d,"nested thing not handled in APS class");
@@ -869,7 +870,7 @@ void dump_some_class_decl(Declaration decl, ostream& oss)
       oss << indent() << "type T_" << n << (is_phylum ? " <: Node" : "")
 	  << ";\n";
       oss << indent() << "val t_" << n << " : C_"
-	  << (is_phylum ? "PHYLUM" : "TYPE")
+	  << (is_phylum ? "PHYLUM" : (is_lattice ? "NULL" : "TYPE"))
 	  << "[T_" << n << "]";
       dump_Type_Signature(some_type_decl_type(d),string("T_") + n,oss);
       oss << ";\n";
@@ -1041,6 +1042,14 @@ static string type_inst_as_scala_type(Type ty)
 #endif
 }
 
+char* concat(const char *s1, const char *s2)
+{
+    char *result = (char *)malloc(strlen(s1) + strlen(s2) + 1); // +1 for the null-terminator
+    strcpy(result, s1);
+    strcat(result, s2);
+    return result;
+}
+
 static void dump_type_inst(string n, string nameArg, Type ti, ostream& oss)
 {
   Module m = type_inst_module(ti);
@@ -1068,7 +1077,17 @@ static void dump_type_inst(string n, string nameArg, Type ti, ostream& oss)
     break;
   case KEYmodule_use:
     // rname = decl_name(module_decl_result_type(USE_DECL(module_use_use(m))));
-    oss << "M_" << symbol_name(use_name(module_use_use(m)));
+
+    {
+
+      // If we have a lattice of an integer then ...
+      const char* n = symbol_name(use_name(module_use_use(m)));
+      bool is_lattice = strstr(n, "LATTICE") ? 1 : 0;
+      const char* name = is_lattice ? concat(n, "_Numeric") : n;
+
+      oss << "M_" << name;
+    }
+
     break;
   }
   bool started = false;

--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -1382,3 +1382,38 @@ class M__basic_24[T_Node <: Node](t_Node:C_PHYLUM[T_Node]) {
     v_x.asInstanceOf[Node].lineNumber;
 };
 
+class M_MAX_LATTICE_Numeric[T_TO <: T_Integer]
+(name : String, t_TO:C_ORDERED[T_TO] with C_NUMERIC[T_TO],v_min_element : T_TO)
+  extends M_MAX_LATTICE[T_TO](name, t_TO, v_min_element)
+  with C_NUMERIC[T_TO]    // <-- New trait thanks to <: T_Integer
+{
+  override def v_zero: T_TO = t_TO.v_zero
+  override def v_one: T_TO = t_TO.v_one
+
+  override val v_plus: (T_TO, T_TO) => T_TO = t_TO.v_plus
+  override val v_minus: (T_TO, T_TO) => T_TO = t_TO.v_minus
+  override val v_times: (T_TO, T_TO) => T_TO = t_TO.v_times
+  override val v_divide: (T_TO, T_TO) => T_TO= t_TO.v_divide
+  override val v_unary_plus: T_TO => T_TO= t_TO.v_unary_plus
+  override val v_unary_minus: T_TO => T_TO = t_TO.v_unary_minus
+  override val v_unary_times: T_TO => T_TO = t_TO.v_unary_times
+  override val v_unary_divide: T_TO => T_TO = t_TO.v_unary_divide
+}
+
+class M_MIN_LATTICE_Numeric[T_TO <: T_Integer]
+(name : String, t_TO:C_ORDERED[T_TO] with C_NUMERIC[T_TO],v_max_element : T_TO)
+  extends M_MIN_LATTICE[T_TO](name, t_TO, v_max_element)
+  with C_NUMERIC[T_TO]    // <-- New trait thanks to <: T_Integer
+{
+  override def v_zero: T_TO = t_TO.v_zero
+  override def v_one: T_TO = t_TO.v_one
+
+  override val v_plus: (T_TO, T_TO) => T_TO = t_TO.v_plus
+  override val v_minus: (T_TO, T_TO) => T_TO = t_TO.v_minus
+  override val v_times: (T_TO, T_TO) => T_TO = t_TO.v_times
+  override val v_divide: (T_TO, T_TO) => T_TO= t_TO.v_divide
+  override val v_unary_plus: T_TO => T_TO= t_TO.v_unary_plus
+  override val v_unary_minus: T_TO => T_TO = t_TO.v_unary_minus
+  override val v_unary_times: T_TO => T_TO = t_TO.v_unary_times
+  override val v_unary_divide: T_TO => T_TO = t_TO.v_unary_divide
+}

--- a/examples/test-coll.aps
+++ b/examples/test-coll.aps
@@ -1,6 +1,10 @@
 with "tiny";
 
 module TEST_COLL[T :: TINY[]] extends T begin
+  
+  type IntegerMaxLattice := MAX_LATTICE[Integer](0);
+  var taha: IntegerMaxLattice := 1 + 2;
+
   type Integers := SET[Integer];
 
   var collection sum : Integer :> 0, (+);

--- a/examples/test.aps
+++ b/examples/test.aps
@@ -6,4 +6,8 @@ module TEST[] begin
   i : Integer := length("hello");
   
   b : Boolean := t = Test${} and Test${} = t;
+
+  type IntegerMaxLattice := MAX_LATTICE[Integer](0);
+
+  l : IntegerMaxLattice := 1 + 3;
 end;


### PR DESCRIPTION
A very hacky solution to fix the two type problems:

```
Type mismatch.
Required: C_NUMERIC [ T_IntegerMaxLattice ] 
Found: M_MAX_LATTICE [ T_Integer ] 
```

```
Type mismatch.
Required: C_TYPE[T_IntegerMaxLattice] with C_MAX_LATTICE[T_IntegerMaxLattice, T_Integer]
Found: M_MAX_LATTICE[T_Integer] 
```