### PR TITLE
wip: feature/type_sig

### DIFF
--- a/analyze/aps-bind.c
+++ b/analyze/aps-bind.c
@@ -341,6 +341,7 @@ static SCOPE type_services(Type t)
 	  } else {
 	    services = type_services(ty);
 	  }
+    Type_info(ty)->type_sig = some_type_decl_sig(tdecl);
 	}
 	break;
       case KEYphylum_decl:

--- a/analyze/aps-bind.c
+++ b/analyze/aps-bind.c
@@ -341,7 +341,6 @@ static SCOPE type_services(Type t)
 	  } else {
 	    services = type_services(ty);
 	  }
-    Type_info(ty)->type_sig = some_type_decl_sig(tdecl);
 	}
 	break;
       case KEYphylum_decl:

--- a/analyze/aps-info.h
+++ b/analyze/aps-info.h
@@ -159,6 +159,7 @@ struct Type_info {
   Type next_type_actual; /* in a series of type actuals */
   void *binding_temporary;
   char *impl_type;
+  Signature  *type_sig;
 };
 extern struct Type_info *Type_info(Type);
 #define TYPE_NEXT(type) (Type_info(type)->next_type_actual)

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -189,37 +189,27 @@ Signature infer_type_sig(TypeEnvironment scope, Type type) {
 // Code taken from type_inst type checking 
 TypeEnvironment build_type_inst_type_environment(Type ty)
 {
-	  Use mu = module_use_use(type_inst_module(ty));
-	  Declaration mdecl = USE_DECL(mu);
-	  Declaration rdecl = module_decl_result_type(mdecl);
-	  Def rdef = some_type_decl_def(rdecl);
-	  TypeEnvironment te = (TypeEnvironment)HALLOC(sizeof(struct TypeContour));
-	  Declaration tdecl = (Declaration)tnode_parent(ty);
-	  Use tu;
-	  Use u;
-	  Type fty;
+  Use mu = module_use_use(type_inst_module(ty));
+  Declaration mdecl = USE_DECL(mu);
+  Declaration rdecl = module_decl_result_type(mdecl);
+  Def rdef = some_type_decl_def(rdecl);
+  TypeEnvironment te = (TypeEnvironment)HALLOC(sizeof(struct TypeContour));
+  Declaration tdecl = (Declaration)tnode_parent(ty);
+  Use tu;
+  Use u;
+  Type fty;
 
-	  while (ABSTRACT_APS_tnode_phylum(tdecl) != KEYDeclaration)
-	    tdecl = (Declaration)tnode_parent(tdecl);
+  while (ABSTRACT_APS_tnode_phylum(tdecl) != KEYDeclaration)
+    tdecl = (Declaration)tnode_parent(tdecl);
 
-	  te->outer = USE_TYPE_ENV(mu);
-	  te->source = mdecl;
-	  te->type_formals = module_decl_type_formals(mdecl);
-	  te->result = (Declaration)tnode_parent(ty);
-	  te->u.type_actuals = type_inst_type_actuals(ty);
+  te->outer = USE_TYPE_ENV(mu);
+  te->source = mdecl;
+  te->type_formals = module_decl_type_formals(mdecl);
+  te->result = (Declaration)tnode_parent(ty);
+  te->u.type_actuals = type_inst_type_actuals(ty);
 
-    return te;
+  return te;
 }
-
-// Type get_type_inst(Use use) {
-//   while (Use_KEY(use) == KEYqual_use)
-//     use = type_use_use(qual_use_from(use));
-
-//   Declaration decl = USE_DECL(use);
-//   if (decl == KEYtype_decl) {
-
-//   }
-// }
 
 static void* do_typechecking(void* ignore, void*node) {
   // find places where Expression, Pattern or Default is used
@@ -481,9 +471,10 @@ static void* do_typechecking(void* ignore, void*node) {
             }
 
             Type_info(ty)->type_sig = infer_type_sig(te, type_decl_type(decl));
-            printf("%d\n", tnode_line_number(ty));
+            printf("filename: %s.aps\n", aps_yyfilename);
+            printf("type_use line number: %d\ntype: ", tnode_line_number(ty));
             print_Type(ty, stdout);
-            printf("\n");
+            printf("\ninferred_signature:");
             print_Signature(Type_info(ty)->type_sig, stdout);
             printf("\n\n");
             break;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -191,13 +191,8 @@ TypeEnvironment build_type_inst_type_environment(Type ty)
 {
   Use mu = module_use_use(type_inst_module(ty));
   Declaration mdecl = USE_DECL(mu);
-  Declaration rdecl = module_decl_result_type(mdecl);
-  Def rdef = some_type_decl_def(rdecl);
   TypeEnvironment te = (TypeEnvironment)HALLOC(sizeof(struct TypeContour));
   Declaration tdecl = (Declaration)tnode_parent(ty);
-  Use tu;
-  Use u;
-  Type fty;
 
   while (ABSTRACT_APS_tnode_phylum(tdecl) != KEYDeclaration)
     tdecl = (Declaration)tnode_parent(tdecl);

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -164,6 +164,11 @@ Signature infer_type_sig(TypeEnvironment scope, Type type) {
     // Mix in together signatures
     Signature result_sig = mult_sig(self_sig, parent_inferred_signature);
 
+    if (strcmp("Result", decl_name(module_decl_result_type(class_decl))) != 0) {
+      Signature result_decl_sig = infer_type_sig(scope, type_decl_type(module_decl_result_type(class_decl)));
+      result_sig = mult_sig(result_sig, result_decl_sig);
+    }
+
     return result_sig;
   }
   case KEYno_type:

--- a/examples/test.aps
+++ b/examples/test.aps
@@ -1,7 +1,18 @@
-module TEST[ElemType] begin
-  type SelfT := LIST[Result];
-  self : LIST[Integer] := SelfT${};
+module NestedModule[Amir] begin
+end;
+
+module TEST[Amir] :: NestedModule[] begin
+  type NestedT := LIST[Amir];
+  variable : NestedT := NestedT${};
 end;
 
 type TestT := TEST[Integer];
-testSelf : LIST[Integer] := TestT$self;
+
+constructor contour() : TestT;
+
+outside : TestT$NestedT := TestT$variable; 
+testInstance : TestT := contour();
+
+type IntegerMaxLattice := MAX_LATTICE[Integer](0);
+
+var latticeInstance: IntegerMaxLattice := 1 + 2;

--- a/examples/test.aps
+++ b/examples/test.aps
@@ -1,9 +1,7 @@
-module TEST[] begin
-  type Test := LIST[String];
-  
-  t : Test := Test$single("hello,") ++ Test$single(" world");
-
-  i : Integer := length("hello");
-  
-  b : Boolean := t = Test${} and Test${} = t;
+module TEST[ElemType] begin
+  type SelfT := LIST[Result];
+  self : LIST[Integer] := SelfT${};
 end;
+
+type TestT := TEST[Integer];
+testSelf : LIST[Integer] := TestT$self;


### PR DESCRIPTION
- 4/11/2020: code finds type of type_use
  - understand Result
  - understands qual use
- 4/9/2020: basic type replacement working

Log:
```
filename: basic.aps
type_use line number: 85
type: Result
inferred_signature:NULL_TYPE[]NULL[]<nosig>

filename: basic.aps
type_use line number: 85
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 86
type: Result
inferred_signature:NULL_TYPE[]NULL[]<nosig>

filename: basic.aps
type_use line number: 86
type: Result
inferred_signature:NULL_TYPE[]NULL[]<nosig>

filename: basic.aps
type_use line number: 86
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 87
type: Result
inferred_signature:NULL_TYPE[]NULL[]<nosig>

filename: basic.aps
type_use line number: 87
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 98
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 99
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 104
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 105
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 107
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 107
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 107
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 108
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 108
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 108
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 109
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 109
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 116
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 117
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 118
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 127
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 133
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 133
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 134
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 134
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 134
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 135
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 135
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 135
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 136
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 136
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 136
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 137
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 137
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 137
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 138
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 138
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 138
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 139
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 139
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 139
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 140
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 140
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 142
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 158
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 159
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 168
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 169
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 170
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 179
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 180
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 181
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 186
type: IEEEsingle
inferred_signature:IEEE[]REAL[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 186
type: IEEEdouble
inferred_signature:IEEE[]REAL[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 187
type: IEEEdouble
inferred_signature:IEEE[]REAL[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 187
type: IEEEsingle
inferred_signature:IEEE[]REAL[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 189
type: IEEEdouble
inferred_signature:IEEE[]REAL[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 193
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 194
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 195
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 196
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 201
type: Character
inferred_signature:CHARACTER[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 201
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 202
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 202
type: Character
inferred_signature:CHARACTER[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 203
type: Character
inferred_signature:CHARACTER[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 204
type: Character
inferred_signature:CHARACTER[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 216
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 218
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 220
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 221
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 227
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 228
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 237
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 239
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 259
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 263
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 264
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 265
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 266
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 283
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 284
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 295
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 296
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 311
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 311
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 326
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 326
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 326
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 327
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 327
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 327
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 328
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 328
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 328
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 329
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 329
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 329
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 364
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 390
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 391
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 392
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 393
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 399
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 399
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 400
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 400
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 401
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 401
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 402
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 402
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 418
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 419
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 422
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 423
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 424
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 425
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 440
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 441
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 442
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 443
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 444
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 457
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 491
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 493
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 495
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 496
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 497
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 498
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 499
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 499
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 500
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 500
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 501
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 501
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 502
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 502
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 510
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 530
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 531
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 532
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 540
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 556
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 557
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 558
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 562
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 563
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 575
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 576
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 577
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 592
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 593
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 594
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 595
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 596
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 596
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 597
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 597
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 598
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 598
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 599
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 599
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 607
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 608
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 609
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 624
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 625
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 626
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 627
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 628
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 628
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 629
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 629
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 630
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 630
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 631
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 631
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 657
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 671
type: Result
inferred_signature:LIST[Character]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Character]READ_ONLY_ORDERED_COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>

filename: basic.aps
type_use line number: 671
type: Result
inferred_signature:LIST[Character]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Character]READ_ONLY_ORDERED_COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>

filename: basic.aps
type_use line number: 671
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 672
type: Result
inferred_signature:LIST[Character]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Character]READ_ONLY_ORDERED_COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>

filename: basic.aps
type_use line number: 672
type: Result
inferred_signature:LIST[Character]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Character]READ_ONLY_ORDERED_COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>

filename: basic.aps
type_use line number: 672
type: Boolean
inferred_signature:BOOLEAN[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 673
type: Result
inferred_signature:LIST[Character]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Character]READ_ONLY_ORDERED_COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>COLLECTION[Character]READ_ONLY_COLLECTION[Character]<nosig>

filename: basic.aps
type_use line number: 673
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 679
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 682
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 682
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 682
type: Range
inferred_signature:LIST[Integer]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Integer]READ_ONLY_ORDERED_COLLECTION[Integer]READ_ONLY_COLLECTION[Integer]<nosig>COLLECTION[Integer]READ_ONLY_COLLECTION[Integer]<nosig>

filename: basic.aps
type_use line number: 688
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 694
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 699
type: String
inferred_signature:STRING[]ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: basic.aps
type_use line number: 702
type: Integer
inferred_signature:INTEGER[]NUMERIC[]BASIC[]NULL[]<nosig>ORDERED[]COMPARABLE[]BASIC[]NULL[]<nosig>PRINTABLE[]<nosig>

filename: test.aps
type_use line number: 6
type: NestedT
inferred_signature:LIST[Amir]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Amir]READ_ONLY_ORDERED_COLLECTION[Amir]READ_ONLY_COLLECTION[Amir]<nosig>COLLECTION[Amir]READ_ONLY_COLLECTION[Amir]<nosig>

filename: test.aps
type_use line number: 11
type: TestT
inferred_signature:TEST[Integer]NestedModule[]<nosig>

filename: test.aps
type_use line number: 13
type: TestT$TEST[Integer].NestedT
inferred_signature:LIST[Integer]BASIC[]NULL[]<nosig>CONCATENATING[]<nosig>ORDERED_COLLECTION[Integer]READ_ONLY_ORDERED_COLLECTION[Integer]READ_ONLY_COLLECTION[Integer]<nosig>COLLECTION[Integer]READ_ONLY_COLLECTION[Integer]<nosig>

filename: test.aps
type_use line number: 14
type: TestT
inferred_signature:TEST[Integer]NestedModule[]<nosig>

filename: test.aps
type_use line number: 18
type: IntegerMaxLattice
inferred_signature:MAX_LATTICE[Integer]<nosig>MAKE_LATTICE[Integer]COMBINABLE[]<nosig>LATTICE[]COMPLETE_PARTIAL_ORDER[]BASIC[]NULL[]<nosig>
```