### PR TITLE
Fix all compiler warnings related to hashcons and canonical types

### DIFF
--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -409,11 +409,11 @@ static void* validate_canonicals(void* ignore, void*node) {
         fclose(f);
 
         char expected[BUFFER_SIZE];
-        sprintf(expected, "%s", expected_string);
+        sprintf(expected, "%s", (char *)expected_string);
 
         // Remove double quotes from the beginning and the end of string
         // This is needed because APS parser does not trim double quotes from KEYstring_const
-        char* expected_cleaned = trim_string_const_token(&expected);
+        char* expected_cleaned = trim_string_const_token(expected);
         
         if (strcmp(actual_to_string, expected_cleaned) != 0) {
           aps_error(type,"Failed: %d  expected `%s` but got `%s`", tnode_line_number(type), expected_cleaned, actual_to_string);
@@ -429,7 +429,7 @@ static void* validate_canonicals(void* ignore, void*node) {
 static Declaration module_TYPE;
 static Declaration module_PHYLUM;
 
-static void set_root_phylum(void *ignore, void *node)
+static void* set_root_phylum(void *ignore, void *node)
 {
   switch (ABSTRACT_APS_tnode_phylum(node))
   {

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -416,7 +416,12 @@ static void* validate_canonicals(void* ignore, void*node) {
         char* expected_cleaned = trim_string_const_token(expected);
         
         if (strcmp(actual_to_string, expected_cleaned) != 0) {
-          aps_error(type,"Failed: %d  expected `%s` but got `%s`", tnode_line_number(type), expected_cleaned, actual_to_string);
+          char type_to_str[BUFFER_SIZE];
+          f = fmemopen(type_to_str, sizeof(type_to_str), "w");
+          print_Type(type, f);
+          fclose(f);
+
+          aps_error(type,"Failed: `%s`:%d expected `%s` but got `%s`", type_to_str, tnode_line_number(type), expected_cleaned, actual_to_string);
         }
       }
     }

--- a/analyze/canonical-signature.c
+++ b/analyze/canonical-signature.c
@@ -4,8 +4,6 @@
 #include "aps-ag.h"
 #include "jbb-alloc.h"
 
-int hash_source_class(Declaration cl);
-
 static CanonicalSignatureSet from_sig(Signature sig);
 static CanonicalSignatureSet from_type(Type t);
 static CanonicalSignatureSet from_declaration(Declaration decl);
@@ -123,9 +121,9 @@ void print_canonical_signature_set(void *untyped, FILE *f)
  * @param types
  * @return combined hash 
  */
-int hash_canonical_types(int count, CanonicalType **types)
+long hash_canonical_types(int count, CanonicalType **types)
 {
-  int h = 7;
+  long h = 17;
   int i;
   for (i = 0; i < count; i++)
   {
@@ -140,9 +138,9 @@ int hash_canonical_types(int count, CanonicalType **types)
  * @param cl Declaration
  * @return hash integer value
  */
-int hash_source_class(Declaration cl)
+long hash_source_class(Declaration cl)
 {
-  return (int)cl;
+  return (long)cl;
 }
 
 /**
@@ -150,7 +148,7 @@ int hash_source_class(Declaration cl)
  * @param untyped InferredSignature
  * @return hash integer value
  */
-int canonical_signature_hash(void *untyped)
+long canonical_signature_hash(void *untyped)
 {
   CanonicalSignature *inferred_sig = (CanonicalSignature *)untyped;
 

--- a/analyze/canonical-signature.h
+++ b/analyze/canonical-signature.h
@@ -29,10 +29,17 @@ CanonicalSignatureSet infer_canonical_signatures(CanonicalType *ctype);
 void initialize_canonical_signature(Declaration module_PHYLUM, Declaration type_PHYLUM);
 
 /**
- * Given a canonical type, prints it to the file output
+ * Given a canonical signature, prints it to the file output
  * @param untyped untyped canonical type
  * @return f FILE output
  */
 void print_canonical_signature(void *untyped, FILE *f);
+
+/**
+ * Given a canonical signature set, prints it to the file output
+ * @param untyped untyped canonical type
+ * @return f FILE output
+ */
+void print_canonical_signature_set(void *untyped, FILE *f);
 
 #endif

--- a/analyze/canonical-type.c
+++ b/analyze/canonical-type.c
@@ -635,12 +635,12 @@ static CanonicalType *canonical_type_left_refactor(CanonicalType *ctype_left, Ca
   switch (ctype_right->key)
   {
   case KEY_CANONICAL_USE:
-  {    
+  {
     struct Canonical_use_type *ctype_right_use = (struct Canonical_use_type *)ctype_right;
     return new_canonical_type_qual(ctype_left, ctype_right_use->decl);
   }
   case KEY_CANONICAL_QUAL:
-  {    
+  {
     struct Canonical_qual_type *ctype_right_qual = (struct Canonical_qual_type *)ctype_right;
     return new_canonical_type_qual(canonical_type_left_refactor(ctype_left, ctype_right_qual->source), ctype_right_qual->decl);
   }

--- a/analyze/canonical-type.h
+++ b/analyze/canonical-type.h
@@ -85,7 +85,7 @@ Declaration canonical_type_decl(CanonicalType *canonical_type);
  * @arg untyped CanonicalType
  * @return hash value
  */
-int canonical_type_hash(void *arg);
+long canonical_type_hash(void *arg);
 
 /**
  * Given a canonical type, prints it to the file output

--- a/analyze/hashcons.c
+++ b/analyze/hashcons.c
@@ -165,7 +165,7 @@ static bool hashcons_set_equal(void *untyped1, void *untyped2)
 
   if (set_a->num_elements != set_b->num_elements) return false;
 
-  int i, hash = 0;
+  int i;
   for (i = 0; i < set_a->num_elements; i++)
   {
     if (set_a->elements[i] != set_b->elements[i]) return false;
@@ -203,7 +203,7 @@ HASH_CONS_SET new_hash_cons_set(HASH_CONS_SET set)
       j--; 
     }
 
-    sorted_set->elements[j + 1] = key;
+    sorted_set->elements[j + 1] = set->elements[i];
     sorted_set->num_elements++;
   }
 

--- a/analyze/hashcons.c
+++ b/analyze/hashcons.c
@@ -28,7 +28,7 @@ void hc_initialize(HASH_CONS_TABLE hc, const int capacity)
  */
 static int hc_candidate_index(HASH_CONS_TABLE hc, void *item)
 {
-  int hash = hc->hashf(item) & INT_MAX;
+  long hash = hc->hashf(item) & LONG_MAX;
   int index = hash % hc->capacity;
   int step_size = hash % (hc->capacity - 2) + 1;
 
@@ -142,12 +142,13 @@ void *hash_cons_get(void *item, size_t temp_size, HASH_CONS_TABLE hc)
  * @param untyped InferredSignature
  * @return hash integer value
  */
-static int hashcons_set_hash(void *untyped)
+static long hashcons_set_hash(void *untyped)
 {
   HASH_CONS_SET set = (HASH_CONS_SET)untyped;
 
-  int i, hash = 17;
-  for (i = 0; i < set->num_elements; i++) hash |= ((int)set->elements[i]);
+  int i;
+  long hash = 17;
+  for (i = 0; i < set->num_elements; i++) hash |= ((long)set->elements[i]);
 
   return hash;
 }
@@ -194,10 +195,10 @@ HASH_CONS_SET new_hash_cons_set(HASH_CONS_SET set)
   int i, j;
   for (i = 0; i < set->num_elements; i++)
   {
-    int key = (int) set->elements[i]; 
+    long key = (long) set->elements[i]; 
     int j = i - 1;
 
-    while (j >= 0 && (int)sorted_set->elements[j] > key)
+    while (j >= 0 && (long)sorted_set->elements[j] > key)
     { 
       sorted_set->elements[j + 1] = sorted_set->elements[j]; 
       j--; 
@@ -292,10 +293,10 @@ HASH_CONS_SET union_hash_const_set(HASH_CONS_SET set_a, HASH_CONS_SET set_b)
  * @param string
  * @return intger hash value
  */
-int hash_string(char *str)
+long hash_string(char *str)
 {
-  int hash = 5381;
-  int c;
+  long hash = 5381;
+  long c;
 
   while ((c = *str++))
   {
@@ -311,9 +312,9 @@ int hash_string(char *str)
  * @param hash2
  * @return combined hash 
  */
-int hash_mix(int h1, int h2)
+long hash_mix(long h1, long h2)
 {
-  int hash = 17;
+  long hash = 17;
   hash = hash * 31 + h1;
   hash = hash * 31 + h2;
   return hash;

--- a/analyze/hashcons.h
+++ b/analyze/hashcons.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-typedef int (*Hash_Cons_Hash)(void *);
+typedef long (*Hash_Cons_Hash)(void *);
 typedef bool (*Hash_Cons_Equal)(void *, void *);
 
 typedef struct hash_cons_table {
@@ -64,7 +64,7 @@ void *hash_cons_get(void *temp_item, size_t temp_size, HASH_CONS_TABLE table);
  * @param string
  * @return intger hash value
  */
-int hash_string(char *str);
+long hash_string(char *str);
 
 /**
  * Combine two hash values into one
@@ -72,6 +72,6 @@ int hash_string(char *str);
  * @param hash2
  * @return combined hash
  */
-int hash_mix(int h1, int h2);
+long hash_mix(long h1, long h2);
 
 #endif


### PR DESCRIPTION
Issues fixed:

1) The compiler doesn't do an implicit conversion between

`struct Canonical_use_type` and `CanonicalType`
`struct Canonical_qual_type` and `CanonicalType`

So it thinks there is something is wrong with the code. But there is nothing wrong because:

```c
struct canonicalTypeBase
{
  int key;
};
typedef struct canonicalTypeBase CanonicalType;

struct Canonical_use_type
{
  int key; /* KEY_CANONICAL_USE */
  Declaration decl;
};

struct Canonical_qual_type
{
  int key; /* KEY_CANONICAL_QUAL */
  Declaration decl;
  CanonicalType *source;
};
```

2) `int` in C is 4 bytes but pointer size is 8 bytes in a 64-bit system and we are using "pointer" as hash values. So we need to use `long` instead of `int` for hash values.

Ran regressions tests and test canonicals. All good. 