### PR TITLE
Removed un-used variable that was causing compiler warning

### DIFF
--- a/aps2scala/dump-scala.cc
+++ b/aps2scala/dump-scala.cc
@@ -861,8 +861,6 @@ void dump_TypeDecl_Traits(Declaration tdecl, Type ti, string n, ostream &oss)
   int nesting_level = 2;
   oss << indent(nesting_level) << "/* dumping traits */" << "\n";
 
-  TypeActuals tas = type_inst_type_actuals(ti);
- 
   vector<Declaration> sv;
   ServiceRecord sr;
 


### PR DESCRIPTION
Just removed an unused variable in canonicals code generation. It kept showing up as a compiler warning each time I build the code.