### PR TITLE
Create lib directory (if not exist) before moving jar file into it

### DIFF
--- a/base/scala/Makefile
+++ b/base/scala/Makefile
@@ -2,13 +2,14 @@
 
 SCALA= aps-impl.scala basic.handcode.scala table.handcode.scala
 SVERSION=2.12
+LIB=../../lib
 
 # We can't make 2.9 anymore because it doesn't understand Java 8
 
 all : aps-library-2.10.jar aps-library-2.11.jar aps-library-2.12.jar
 
 install : 
-	cp aps-library*.jar ../../lib
+	mkdir -p ${LIB} && cp aps-library*.jar ${LIB}
 
 aps-library-2.9.jar : ${SCALA}
 	@rm -f *.class


### PR DESCRIPTION
-p flag will make sure we don't get an error if the folder is already there.

I tested it locally, if the folder is already there it will just replace the jar file. All working as expected.