### PR TITLE
Group scheduler + code generation

### DIFF
--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -2850,3 +2850,35 @@ void print_cycles(STATE *s, FILE *stream) {
     }
   }
 }
+
+
+/**
+ * Utility function that determines whether fibered attribute is circular or not.
+ * if a fiber_attr is circular, which is true if the fiber is empty and the attribute
+ * (local or node attribute) is declared circular, OR (if the fiber is non-empty) if
+ * the last step in the fiber is circular.
+ * Note that a.b.c. is repsented as short = a.b, field = c 
+ * @param fiber_attr fibered attribute pointer
+ * @return boolean indicating the circularity 
+ */
+BOOL fiber_attr_circular(FIBERED_ATTRIBUTE* fiber_attr)
+{
+  // If fiber is empty
+  if (fiber_attr->fiber == base_fiber || fiber_attr->fiber == NULL)
+  {
+    return decl_is_circular(fiber_attr->attr);
+  }
+
+  FIBER fiber = fiber_attr->fiber;
+  return decl_is_circular(fiber->field);
+}
+
+/**
+ * Utility function indicating whether INSTANCE (attribute instance) is circular or not
+ * @param in attribute instance
+ * @return boolean indicating the circularity 
+ */
+BOOL instance_circular(INSTANCE* in)
+{
+  return fiber_attr_circular(&in->fibered_attr);
+}

--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -2851,7 +2851,6 @@ void print_cycles(STATE *s, FILE *stream) {
   }
 }
 
-
 /**
  * Utility function that determines whether fibered attribute is circular or not.
  * if a fiber_attr is circular, which is true if the fiber is empty and the attribute

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -79,6 +79,7 @@ typedef struct summary_dependency_graph {
   DEPENDENCY *mingraph; /* two-d array, indexed by instance number */
   struct summary_dependency_graph *next_in_phy_worklist;
   int *summary_schedule; /* one-d array, indexed by instance number */
+  BOOL* cyclic_flags; /* one-d array, indexed by phase number indicating whether phase is circular or not */
 } PHY_GRAPH;
 extern const char *phy_graph_name(PHY_GRAPH *);
   

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -66,6 +66,7 @@ typedef struct augmented_dependency_graph {
   struct augmented_dependency_graph *next_in_aug_worklist;
   int *schedule; /* one-d array, indexed by instance number */
   struct cto_node *total_order;
+  Declaration* children;
 } AUG_GRAPH;
 extern const char *aug_graph_name(AUG_GRAPH *);
 

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -21,6 +21,8 @@ typedef struct attribute_instance {
 enum instance_direction {instance_local, instance_inward, instance_outward};
 enum instance_direction fibered_attr_direction(FIBERED_ATTRIBUTE *fa);
 enum instance_direction instance_direction(INSTANCE *);
+extern BOOL fiber_attr_circular(FIBERED_ATTRIBUTE* fiber_attr);
+extern BOOL instance_circular(INSTANCE* in);
 
 typedef unsigned DEPENDENCY;
 

--- a/analyze/aps-oag.c
+++ b/analyze/aps-oag.c
@@ -770,7 +770,7 @@ static CTO_NODE* schedule_transitions(AUG_GRAPH *aug_graph, CTO_NODE* prev, COND
     return cto_node;
   }
 
-  // If we find ourselves scheduling <-ph,-1> and there is nothing else to do in this group then work on the first child if any
+  // If we find ourselves scheduling <-ph,-1> and there is nothing else to do in this group then work on the first child <ph, 0> if any
   if (group->ph < 0 && group->ch == -1)
   {
     CHILD_PHASE *child_group = (CHILD_PHASE*)HALLOC(sizeof(CHILD_PHASE));
@@ -788,7 +788,7 @@ static CTO_NODE* schedule_transitions(AUG_GRAPH *aug_graph, CTO_NODE* prev, COND
 
   CHILD_PHASE *child_group = NULL;
   // Don't leave this phase without completing everything
-  // Probe whether there is more child attribute instance in this phase ready to be scheduled
+  // Probe whether there is more attribute instance in this phase ready to be scheduled
   if (is_there_more_to_schedule_in_phase(aug_graph, cond, instance_groups, group->ph, &child_group))
   {
     return schedule_visits_group(aug_graph, prev, cond, instance_groups, remaining, child_group);

--- a/analyze/aps-oag.c
+++ b/analyze/aps-oag.c
@@ -932,7 +932,6 @@ static CTO_NODE* schedule_visits(AUG_GRAPH *aug_graph, CTO_NODE* prev, CONDITION
 static Declaration* get_aug_graph_children(AUG_GRAPH *aug_graph)
 {
   Declaration source = aug_graph->match_rule;
-
   switch (Declaration_KEY(source))
   {
   case KEYtop_level_match:
@@ -947,7 +946,6 @@ static Declaration* get_aug_graph_children(AUG_GRAPH *aug_graph)
 
     int i = 0;
     Declaration* result = (Declaration*)HALLOC(sizeof(Declaration) * count);
-
     formal = top_level_match_first_rhs_decl(source);
     while (formal != NULL)
     {
@@ -972,7 +970,6 @@ static Declaration* get_aug_graph_children(AUG_GRAPH *aug_graph)
 
     int i = 0;
     Declaration* result = (Declaration*)HALLOC(sizeof(Declaration) * count);
-
     child = first_Declaration(block_body(some_class_decl_contents(source)));
     while (child != NULL)
     {
@@ -997,7 +994,6 @@ static Declaration* get_aug_graph_children(AUG_GRAPH *aug_graph)
 
     int i = 0;
     Declaration* result = (Declaration*)HALLOC(sizeof(Declaration) * count);
-
     formal = first_Declaration(function_type_formals(some_function_decl_type(source)));
     while (formal != NULL)
     {

--- a/analyze/aps-oag.c
+++ b/analyze/aps-oag.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include "jbb.h"
 #include "jbb-alloc.h"
 #include "aps-ag.h"
@@ -607,27 +608,58 @@ static bool is_there_more_to_schedule_in_group(AUG_GRAPH *aug_graph, CHILD_PHASE
  * @param min_ch min value for ch
  * @return boolean indicating if there is more in this group that needs to be scheduled
  */
-static BOOL is_there_more_to_schedule_in_phase(AUG_GRAPH *aug_graph, CONDITION cond, CHILD_PHASE* instance_groups, short phase, CHILD_PHASE** ret_group)
+static BOOL find_child_attribute(AUG_GRAPH *aug_graph, CONDITION cond, CHILD_PHASE* instance_groups, short phase, CHILD_PHASE** ret_group)
 {
+  if (oag_debug & DEBUG_ORDER)
+  {
+    printf("Testing whether there is any child attributes in phase %d ready to be scheduled.\n", abs(phase));
+  }
+
   int n = aug_graph->instances.length;
   int i;
+  int current_ph = SHRT_MAX;
+  CHILD_PHASE* current_group =  NULL;
+
   for (i = 0; i < n; i++)
   {
     // Instance in the same group but cannot be considered
     CHILD_PHASE *group_key = &instance_groups[i];
 
-    // Check if in the same group
-    if (abs(phase) == abs(group_key->ph) && group_ready_to_go(aug_graph, instance_groups, cond, i))
+    // Check if in the same group AND its phase is less than current phase
+    // This is needed to make sure we always schedule inherited attributes (negative phase) first
+    if (abs(phase) == abs(group_key->ph) && group_key->ph < current_ph && aug_graph->schedule[i] == 0)
     {
+      if (!group_ready_to_go(aug_graph, instance_groups, cond, i))
+      {
+        if (oag_debug & DEBUG_ORDER)
+        {
+          printf("Attribute not ready: ");
+          print_instance(&aug_graph->instances.array[i], stdout);
+          printf(" <%d,%d> \n", group_key->ph, group_key->ch);
+        }
+        continue;
+      }
+
       if (aug_graph->schedule[i] == 0)
       {
-        *ret_group = group_key;
-        return TRUE;
+        current_group = group_key;
+        current_ph = group_key->ph;
       }
     }
   }
 
-  return FALSE;
+  if (current_group != NULL)
+  {
+    if (oag_debug & DEBUG_ORDER)
+    {
+      printf("Child phase <%d,%d> is ready to be scheduled.\n", current_group->ph, current_group->ch);
+    }
+
+    *ret_group = current_group;
+    return true;
+  }
+
+  return false;
 }
 
 // Signature of function
@@ -646,11 +678,15 @@ static void assert_locals_order(AUG_GRAPH *aug_graph, CHILD_PHASE* instance_grou
 
   for (i = 0; i < n; i++)
   {
-    if (instance_is_local(aug_graph, instance_groups, i) && aug_graph->schedule[i])
+    if (instance_is_local(aug_graph, instance_groups, i) &&
+        if_rule_p(aug_graph->instances.array[i].fibered_attr.attr) &&
+        aug_graph->schedule[i])
     {
       for (j = 0; j < i; j++)
       {
-        if (instance_is_local(aug_graph, instance_groups, j) && !aug_graph->schedule[j])
+        if (instance_is_local(aug_graph, instance_groups, j) &&
+            if_rule_p(aug_graph->instances.array[j].fibered_attr.attr) &&
+            !aug_graph->schedule[j])
         {
           fprintf(stderr, "Scheduled local:\n\t");
           print_instance(&aug_graph->instances.array[i], stderr);
@@ -666,64 +702,35 @@ static void assert_locals_order(AUG_GRAPH *aug_graph, CHILD_PHASE* instance_grou
 }
 
 /**
- * Utility function to greedy schedule as many locals as possible
- * @param aug_graph Augmented dependency graph
- * @param prev previous CTO node
- * @param cond current CONDITION
- * @param instance_groups array of <ph,ch> indexed by INSTANCE index
- * @param remaining count of remaining instances to schedule
- * @param group parent group key
- * @return head of linked list
+ * Function that throws an error if phases are out of order
+ * @param current head of linkedlist
+ * @param ph current value of ph being investigated
  */
-static CTO_NODE* schedule_locals(AUG_GRAPH *aug_graph, CTO_NODE* prev, CONDITION cond, CHILD_PHASE* instance_groups, int remaining, CHILD_PHASE* prev_group)
+static void assert_total_order(CTO_NODE *current, short ph)
 {
-  int i;
-  int n = aug_graph->instances.length;
-  int sane_remaining = 0;
-  CTO_NODE* cto_node = prev;
+  if (current == NULL) return;
 
-  for (i = 0; i < n; i++)
+  short new_ph = ph;
+
+  if (current->cto_instance == NULL)
   {
-    INSTANCE *instance = &aug_graph->instances.array[i];
-    CHILD_PHASE *group = &instance_groups[i];
-
-    // Already scheduled OR instance is not local then ignore
-    if (aug_graph->schedule[i] != 0 || !instance_is_local(aug_graph, instance_groups, i))
+    if (current->child_phase.ch == -1)
     {
-      continue;
+      new_ph +=1;
     }
-
-    sane_remaining++;
-
-    cto_node = (CTO_NODE*)HALLOC(sizeof(CTO_NODE));
-    cto_node->cto_prev = prev;
-    cto_node->cto_instance = instance;
-    cto_node->child_phase = instance_groups[i];
-
-    aug_graph->schedule[i] = 1; // instance has been scheduled (and will not be considered for scheduling in the recursive call)
-
-    if (if_rule_p(instance->fibered_attr.attr))
-    {
-      int cmask = 1 << (if_rule_index(instance->fibered_attr.attr));
-      cond.negative |= cmask;
-      cto_node->cto_if_false = schedule_locals(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
-      cond.negative &= ~cmask;
-      cond.positive |= cmask;
-      cto_node->cto_if_true = schedule_locals(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
-      cond.positive &= ~cmask;
-    }
-    else
-    {
-      cto_node->cto_next = schedule_locals(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
-    }
-
-    aug_graph->schedule[i] = 0; // Release it
-
-    return cto_node;
+  }
+  else if (if_rule_p(current->cto_instance->fibered_attr.attr))
+  {
+    assert_total_order(current->cto_if_true, new_ph);
   }
 
-  // Fall back to normal scheduler
-  return schedule_visits(aug_graph, prev, cond, instance_groups, remaining /* no change */, prev_group);
+  if (current->child_phase.ph != 0 && abs(current->child_phase.ph) != ph)
+  {
+    fatal_error("Total order is invalid. Expected a phase %d but received a node <%d,%d>.", ph, current->child_phase.ph, current->child_phase.ch);
+    return;
+  }
+
+  assert_total_order(current->cto_next, new_ph);
 }
 
 /**
@@ -770,32 +777,20 @@ static CTO_NODE* schedule_transitions(AUG_GRAPH *aug_graph, CTO_NODE* prev, COND
     return cto_node;
   }
 
-  // If we find ourselves scheduling <-ph,-1> and there is nothing else to do in this group then work on the first child <ph, 0> if any
+  // If we find ourselves scheduling <-ph,-1> and there is nothing else to do in this group then
+  // work on the first child <[+-]ph, 0> if any
   if (group->ph < 0 && group->ch == -1)
   {
-    CHILD_PHASE *child_group = (CHILD_PHASE*)HALLOC(sizeof(CHILD_PHASE));
-    child_group->ph = group->ph;
-    child_group->ch = 0;
+    CHILD_PHASE *child_group = NULL;
 
-    // This check is needed to prevent duplicate visit marker because we should not trigger
-    // group scheduler if there is nothing to be done in that group, doing so will have
-    // unwanted consequences.
-    if (is_there_more_to_schedule_in_group(aug_graph, instance_groups, child_group))
+    if (find_child_attribute(aug_graph, cond, instance_groups, group->ph, &child_group))
     {
       return schedule_visits_group(aug_graph, prev, cond, instance_groups, remaining, child_group);
     }
   }
 
-  CHILD_PHASE *child_group = NULL;
-  // Don't leave this phase without completing everything
-  // Probe whether there is more attribute instance in this phase ready to be scheduled
-  if (is_there_more_to_schedule_in_phase(aug_graph, cond, instance_groups, group->ph, &child_group))
-  {
-    return schedule_visits_group(aug_graph, prev, cond, instance_groups, remaining, child_group);
-  }
-
-  // Try to schedule local if any before falling back and call schedule_visits
-  return schedule_locals(aug_graph, prev, cond, instance_groups, remaining /* no change */, group);
+  // Fallback to normal scheduler
+  return schedule_visits(aug_graph, prev, cond, instance_groups, remaining /* no change */, group);
 }
 
 /**
@@ -959,15 +954,15 @@ static CTO_NODE* schedule_visits(AUG_GRAPH *aug_graph, CTO_NODE* prev, CONDITION
         {
           int cmask = 1 << (if_rule_index(instance->fibered_attr.attr));
           cond.negative |= cmask;
-          cto_node->cto_if_false = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, group);
+          cto_node->cto_if_false = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
           cond.negative &= ~cmask;
           cond.positive |= cmask;
-          cto_node->cto_if_true = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, group);
+          cto_node->cto_if_true = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
           cond.positive &= ~cmask;
         }
         else
         {
-          cto_node->cto_next = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, group);
+          cto_node->cto_next = schedule_visits(aug_graph, cto_node, cond, instance_groups, remaining-1, prev_group);
         }
 
         aug_graph->schedule[i] = 0; // Release it
@@ -1211,12 +1206,15 @@ void schedule_augmented_dependency_graph(AUG_GRAPH *aug_graph) {
     fatal_error("Failed to create total order.");
   }
 
-  // if (oag_debug & DEBUG_ORDER)
+  if (oag_debug & DEBUG_ORDER)
   {
     printf("\nSchedule\n");
     printf("syntax_decl %s\n", decl_name(aug_graph->syntax_decl));
     print_total_order(aug_graph->total_order, 0, stdout);
   }
+
+  // Ensure generated total order is valid
+  assert_total_order(aug_graph->total_order, 1);
 }
 
 void compute_oag(Declaration module, STATE *s) {

--- a/analyze/aps-oag.h
+++ b/analyze/aps-oag.h
@@ -1,9 +1,18 @@
 extern void compute_oag(Declaration,STATE *);
 
-/** Return phase (synthesized) or -phase (inherited)
+/**
+ * Return phase (synthesized) or -phase (inherited)
  * for fibered attribute, given the phylum's summary dependence graph.
  */
 extern int attribute_schedule(PHY_GRAPH *phy_graph, FIBERED_ATTRIBUTE* key);
+
+typedef struct child_phase_type CHILD_PHASE;
+
+struct child_phase_type
+{ 
+  short ph; // Phase: ph is negative for inherited attributes of the visit/phase, positive for synthesized attributes
+  short ch; // Child number: ch is -1 for parent, and otherwise [0,nch)
+};
 
 /** A conditional total order is a tree of cto nodes.
  * null means the CTO is done.
@@ -18,6 +27,8 @@ struct cto_node {
   INSTANCE* cto_instance;
   CTO_NODE* cto_next;
   CTO_NODE* cto_if_true;
+  CHILD_PHASE child_phase;
+  Declaration child_decl;
 #define cto_if_false cto_next
 };
       

--- a/codegen/static-impl.cc
+++ b/codegen/static-impl.cc
@@ -113,7 +113,14 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
       os << indent() << "// aug_graph: " << decl_name(aug_graph->syntax_decl) << "\n";
       os << indent() << "// visit marker(" << ph << "," << ch << ")\n";
 
-      int n = PHY_GRAPH_NUM(Declaration_info(cto->child_decl)->node_phy_graph);
+      PHY_GRAPH* pg = Declaration_info(cto->child_decl)->node_phy_graph;
+      int n = PHY_GRAPH_NUM(pg);
+
+      // If current phase is not circular but visit is circular then fixed-point loop is needed
+      if (current > 0 && !pg->cyclic_flags[current] && pg->cyclic_flags[ph])
+      {
+        os << indent() << "// Fixed-point is needed here.\n";
+      }
 
       os << indent() << "visit_" << n
         << "_" << ph << "(";	

--- a/codegen/static-impl.cc
+++ b/codegen/static-impl.cc
@@ -170,9 +170,10 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
     }
 
     // Instance should not be null for non-visit marker CTO nodes
+    // Visit markers have a form of either: <ph,ch> or <-ph,-1>
     if (in == NULL)
     {
-      fatal_error("total_order is malformed.");
+      fatal_error("total_order is malformed: Instance should not be null for non-visit marker CTO nodes.");
     }
 
     Declaration ad = in->fibered_attr.attr;

--- a/codegen/static-impl.cc
+++ b/codegen/static-impl.cc
@@ -133,7 +133,6 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
       if (current == phase) return true; // phase is over
 
       bool is_mod = false;
-
       switch (Declaration_KEY(aug_graph->syntax_decl))
       {
       case KEYsome_class_decl:

--- a/codegen/static-impl.cc
+++ b/codegen/static-impl.cc
@@ -120,8 +120,9 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
       if (current > 0 && !pg->cyclic_flags[current] && pg->cyclic_flags[ph])
       {
         os << indent() << "// Fixed-point is needed here.\n";
+        dump_fixed_point_loop_visit(cto->child_decl, n, ph, os);
       }
-
+      {
       os << indent() << "visit_" << n
         << "_" << ph << "(";	
 #ifdef APS2SCALA
@@ -130,6 +131,7 @@ static bool implement_visit_function(AUG_GRAPH* aug_graph,
         os << "v_" << decl_name(cto->child_decl);
 #endif /* APS2SCALA */
       os << ");\n";
+      }
 
       continue;
     }


### PR DESCRIPTION
- `schedule_visits_group`: utility function that gets a group as an argument and tries to schedule all nodes in that group 
- `schedule_locals`: utility function that tries to schedule as many locals as possible
- `schedule_visits`: utility function that tries to schedule node that is possible to be scheduled
- `schedule_transitions`: utility function called when group scheduler finishes scheduling a group
- `assert_locals_order`: utility function that asserts that no local is scheduled out of order