### PR TITLE
WIP: Fix add-up down

### DIFF
--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -329,7 +329,9 @@ static bool instance_is_local(INSTANCE *instance)
   {
     switch (Declaration_KEY((Declaration)node))
     {
-    case KEYpragma_call:  // black_dot(...).result is local and the node is a proxy of function_decl
+    // For black_dot(...).result to be considered local, the node of INSTANCE should be a proxy of function_decl
+    // Note that proxies are done using pragma_calls in aps-dnc
+    case KEYpragma_call: 
     case KEYsome_function_decl:
       return true;
     }

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -324,10 +324,9 @@ static bool instance_is_local(INSTANCE *instance)
   if (instance->node ==  NULL) return true;
 
   void* node = instance->node;
-  // Some instance->node use Expression instead of Declaration
+  // Some instance->node are Expression instead of Declaration
   if (ABSTRACT_APS_tnode_phylum(node) == KEYDeclaration)
   {
-    // printf("key: %d\n", Declaration_KEY((Declaration)node));
     switch (Declaration_KEY((Declaration)node))
     {
     case KEYpragma_call:  // black_dot(...).result is local and the node is a proxy of function_decl


### PR DESCRIPTION
Ran regression tests to compare before and after of scheduling for `simple-bindings{1,2,3}` and `*-fiber-cycle`. No change for simple-binding but had issues with fiber-cycles.