### PR TITLE
Broken Simple lexer fixed

### DIFF
--- a/examples/scala/Simple.lex.scala
+++ b/examples/scala/Simple.lex.scala
@@ -32,5 +32,6 @@
   def ID(s : String) = SimpleTokens.ID(s);
   def INT_LITERAL(i:String) = SimpleTokens.INT_LITERAL(Integer.parseInt(i));
   def STR_LITERAL(s:String) = SimpleTokens.STR_LITERAL(s);
+  def YYEOFT = SimpleTokens.YYEOF();
   
 %}

--- a/examples/simple.lex
+++ b/examples/simple.lex
@@ -17,3 +17,4 @@
 
 [ \t\r\n]+	{}
 
+<<EOF>> { return SimpleTokens.YYEOF(); }

--- a/examples/simple.lex
+++ b/examples/simple.lex
@@ -17,4 +17,4 @@
 
 [ \t\r\n]+	{}
 
-<<EOF>> { return SimpleTokens.YYEOF(); }
+<<EOF>> { return YYEOFT; }


### PR DESCRIPTION
There is a `YYEOF` integer variable in JFlex generated scanner file so we have to access the `YYEOF` token using `SimpleTokens.YYEOF`.  If we create a function YYEOF in `Simple.lex.scala` it will conflict with the variable `YYEOF` in generated scanner file. So prefixing it with `SimpleTokens` is the cleanest solution.