### PR TITLE
Fixed the examples to use correct direction and operators

### DIFF
--- a/examples/first.aps
+++ b/examples/first.aps
@@ -28,7 +28,7 @@ module FIRST[T :: var GRAMMAR[]] extends T begin
   match ?self:Item=nonterminal(?s:Symbol) begin
     case DeclarationTable$select(firstTable, s) begin
       match DeclarationTable$table_entry(?,?item_first_objs) begin
-        self.item_first :> item_first_objs;
+        self.item_first := item_first_objs;
       end;
     end;
   end;
@@ -44,11 +44,11 @@ module FIRST[T :: var GRAMMAR[]] extends T begin
   end;
 
   match ?self : Items = Items$none() begin
-    self.items_first :> { epsilon };
+    self.items_first := { epsilon };
   end;
 
   match ?self : Items = Items$single(?item : Item) begin
-    self.items_first :> item.item_first;
+    self.items_first := item.item_first;
   end;
 
   match ?self : Items = Items$append(?items1,?items2 : Items) begin

--- a/examples/follow.aps
+++ b/examples/follow.aps
@@ -21,7 +21,7 @@ module FOLLOW[T :: var GRAMMAR[]] extends T begin
   pragma synthesized(items_predict);
   pragma inherited (items_follow);
 
-  circular attribute Grammar.grammar_follow : DeclarationTable;
+  attribute Grammar.grammar_follow : DeclarationTable;
   pragma synthesized(grammar_follow);
 
   epsilon : Symbol := make_symbol("epsilon");

--- a/examples/nullable.aps
+++ b/examples/nullable.aps
@@ -13,7 +13,7 @@ module NULLABLE[T :: var GRAMMAR[]] extends T begin
   circular attribute Items.items_nullable : OrLattice;
   pragma synthesized(items_nullable);
 
-  circular attribute Grammar.grammar_nullable : NullableTable;
+  attribute Grammar.grammar_nullable : NullableTable;
   pragma synthesized(grammar_nullable);
 
   epsilon : Symbol := make_symbol("epsilon");


### PR DESCRIPTION
Tested it with a new type checker that catches invalid assignments. All good.