### PR TITLE
Fix the issue with patterns

### DIFF
--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -423,8 +423,8 @@ static void *get_match_tests(void *vpexpr, void *node)
   default:
     return NULL;
   case KEYMatch:
-    traverse_Pattern(get_match_tests,vpexpr,matcher_pat((Match)node));
     Match_info((Match)node)->match_test = *pexpr;
+    traverse_Pattern(get_match_tests,vpexpr,matcher_pat((Match)node));
     return NULL;
   case KEYMatches:
   case KEYPatternActuals:


### PR DESCRIPTION
This function sets `->match_test` of `Match`. This is used to create an edge from all the things that need to be done first before `Match` can run. 

For example, given this `Case`, there is only one `Match` and its `->match_test` should be linked list containing `scope.entities` 

```
case scope.entities begin
  match {...,?e:EntityRef if e.entity_name=name,...} begin
    result := e;
  end;
else
```

But the issue is in the recursive call, it gets replaced by  `e.entity_name=name` (see `*pexpr = cond;`). This code is needed when we have nested `Match` inside `Match`. This incorrect order of code causes `e.entity_name=name` (instead of `scope.entities`) to be "test" of surrounding `Match` which is obviously wrong.