### PR TITLE
Fix type checking needed for multi-cycle to work

### DIFF
--- a/analyze/aps-bind.c
+++ b/analyze/aps-bind.c
@@ -262,6 +262,25 @@ static SCOPE inst_services(TypeEnvironment use_type_env,
    *
    * services = signature_services(tdecl,psig,services); 
    */
+  Declaration td = some_class_decl_result_type(class_decl);
+  if (Declaration_KEY(td) == KEYtype_decl) {
+    Type ty = type_decl_type(td);
+    switch (Type_KEY(ty))
+    {
+    case KEYtype_inst:
+    {
+      Module m = type_inst_module(ty);
+      Use u = module_use_use(m);
+      Declaration mdecl = USE_DECL(u);
+      // Cannot use type_inst_type_actuals(ty) here, we need to use
+      // tacts for the "actuals" to be replaced with real type_inst actuals.
+      TypeActuals tas = tacts;
+      services = inst_services(use_type_env, mdecl, td, tas, services);
+      break;
+    }
+    }
+  }
+
   traverse_Block(get_public_bindings,&services,
 		 some_class_decl_contents(class_decl));  
   pop_type_contour(); /* not actually necessary */


### PR DESCRIPTION
In `multi-cycle.aps` we have this:

```
type IntegerLattice := MAX_LATTICE[Integer](-1000);
IntegerLattice$join(0,w.s1)
```

but the problem aps type throws no binding because it doesn't see `$join` and `$meet` function available. The reason is `MAX_LATTICE` is a module that its result is a `MAKE_LATTICE`. This PR enables support for type checking of such scenarios.