### PR TITLE
Additional codes used in the new scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SUBDIRS= utilities parse analyze aps2scala apscpp
 install:
-	-mkdir lib bin
+	-mkdir -p lib bin
 	for d in ${SUBDIRS}; do \
 	  (cd $$d; ${MAKE} install); \
 	done

--- a/analyze/Makefile
+++ b/analyze/Makefile
@@ -5,7 +5,7 @@ PROJECT-DIR=..
 APSAGOBJS= aps-bind.o aps-read.o aps-info.o aps-ag-util.o \
 	  aps-fiber.o aps-cond.o aps-dnc.o aps-cycle.o aps-oag.o \
 	  aps-analyze.o aps-debug.o aps-type.o table.o alist.o \
-	  canonical-signature.o canonical-type.o
+	  canonical-signature.o canonical-type.o aps-scc.o
 APSCOBJS= apsc.o ${APSAGOBJS} 
 APSCLIB= ${PROJECT-DIR}/lib/aps-lib.o
 UTILITIESLIB= ${PROJECT-DIR}/utilities/utilities.o
@@ -28,6 +28,7 @@ aps-cycle.o aps-dnc.o : aps-cycle.h
 aps-debug.o : aps-debug.h
 canonical-type.o : canonical-type.h
 canonical-signature.o : canonical-type.o canonical-signature.h
+aps-scc.o : aps-dnc.o aps-scc.h
 
 install: apsc aps-ag.a
 	mv apsc ../bin/apssched

--- a/analyze/aps-ag.h
+++ b/analyze/aps-ag.h
@@ -19,6 +19,7 @@
 #include "../utilities/utilities.h"
 #include "canonical-type.h"
 #include "canonical-signature.h"
+#include "aps-scc.h"
 
 extern char *aps_yyfilename;
 extern void aps_error(const void *tnode, const char *fmt, ...);

--- a/analyze/aps-bind.c
+++ b/analyze/aps-bind.c
@@ -142,6 +142,8 @@ static SCOPE add_env_item(SCOPE old, Declaration d) {
 	return new_entry;
       }
     }
+  default:
+    break;
   }
   return old;
 }
@@ -278,6 +280,8 @@ static SCOPE inst_services(TypeEnvironment use_type_env,
       services = inst_services(use_type_env, mdecl, td, tas, services);
       break;
     }
+    default:
+      break;
     }
   }
 
@@ -320,6 +324,8 @@ static SCOPE signature_services(Declaration tdecl, Signature sig, SCOPE services
 						 services));
   case KEYfixed_sig:
   case KEYno_sig:
+    break;
+  default:
     break;
   }
   return services;
@@ -411,6 +417,8 @@ static SCOPE type_services(Type t)
   case KEYfunction_type:
   case KEYno_type:
     break;
+  default:
+    break;
   }
   Type_info(t)->binding_temporary = services;
   return services;
@@ -456,6 +464,8 @@ static void bind_Use(Use u, int namespaces, SCOPE scope) {
       }
     }
     break;
+  default:
+    break;
   }
 }
 
@@ -483,8 +493,12 @@ static void *get_bindings(void *scopep, void *node) {
 	  bind_Program(p);
 	  traverse_Program(get_public_bindings,scopep,p);
 	}
+      default:
+        break;
       }
     }
+  default:
+    break;
   }
   return scopep;
 }
@@ -504,8 +518,12 @@ static void *get_public_bindings(void *scopep, void *node) {
 	  }
 	}
 	return NULL;
+      default:
+        break;
       }
     }
+  default:
+    break;
   }
   return scopep;
 }
@@ -570,10 +588,14 @@ static void *do_bind(void *vscope, void *node) {
 		      TYPE_FORMAL_EXTENSION_FLAG;
 		    new_scope=add_ext_sig(new_scope,rdecl,some_type_formal_sig(tf));
 		    break;
+      default:
+        break;
 		  }
 		}
 	      }
 	      break;
+      default:
+        break;
 	    }
 	  }
 	  traverse_Block(do_bind,new_scope,module_decl_contents(d)); }
@@ -628,18 +650,27 @@ static void *do_bind(void *vscope, void *node) {
     switch (Signature_KEY((Signature)node)) {
     case KEYsig_use:
       bind_Use(sig_use_use((Signature)node),NAME_SIGNATURE,scope);
+      break;
+    default:
+      break;
     }
     break;
   case KEYType:
     switch (Type_KEY((Type)node)) {
     case KEYtype_use:
       bind_Use(type_use_use((Type)node),NAME_TYPE,scope);
+      break;
+    default:
+      break;
     }
     break;
   case KEYPattern:
     switch (Pattern_KEY((Pattern)node)) {
     case KEYpattern_use:
       bind_Use(pattern_use_use((Pattern)node),NAME_PATTERN,scope);
+      break;
+    default:
+      break;
     }
     break;
   case KEYExpression:
@@ -655,6 +686,8 @@ static void *do_bind(void *vscope, void *node) {
 	new_scope = bind_Declaration(new_scope,controlled_formal(e));
 	traverse_Expression(do_bind,new_scope,controlled_expr(e));
 	return NULL;
+      default:
+        break;
       }
     }
     break;
@@ -667,6 +700,8 @@ static void *do_bind(void *vscope, void *node) {
 	aps_error(u,"no binding for %s",symbol_name(name));
       }
     }
+    break;
+  default:
     break;
   }
   return vscope;
@@ -739,6 +774,8 @@ static Expression actuals_set_next_actual(Actuals actuals, Expression next) {
       Actuals more = append_Actuals_l2(actuals);
       Expression middle = actuals_set_next_actual(more,next);
       return actuals_set_next_actual(some,middle); }
+  default:
+    break;
   }
   fatal_error("control reached end of actuals_set_next_actual");
   return NULL;
@@ -1067,6 +1104,8 @@ static void *activate_pragmas(void *ignore, void *node) {
 		  Declaration_info(d)->decl_flags |= FIELD_DECL_CYCLIC_FLAG;
 		}
 	      }
+      default:
+        break;
 	    }
 	    break;
 	  case KEYtype_value:
@@ -1085,12 +1124,16 @@ static void *activate_pragmas(void *ignore, void *node) {
 		  Declaration_info(d)->decl_flags |= SELF_MANAGED_FLAG;
 		}
 	      }
+      default:
+        break;
 	    }
 	    break;
 	  }
 	}
       }
       break; 
+    default:
+      break;
     }
   }
   return ignore;

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -22,6 +22,12 @@ static int *parent_index; /* initializes to pi[i] = i */
 static int *constructor_instance_start;
 static int *phylum_instance_start;
 
+
+#define UP_DOWN_DIRECTION(v, direction) (direction ? v : !v)
+#define IS_JUST_FIBER_DEPENDENCY(d) (((d) & DEPENDENCY_MAYBE_SIMPLE))
+#define UP_DOWN (true)
+#define DOWN_UP (false)
+
 static void init_indices(STATE *s) {
   int num = 0;
   int i = 0;
@@ -130,8 +136,7 @@ static void get_fiber_cycles(STATE *s) {
   }
 }
 
-
-/*** determing strongly connected sets of attributes ***/
+/*** determining strongly connected sets of attributes ***/
 
 static void make_augmented_cycles_for_node(AUG_GRAPH *aug_graph,
 					   int constructor_index,
@@ -392,6 +397,22 @@ static void add_up_down_edge(int index1, int index2, int n, INSTANCE *array, DEP
     printf("\n");
   }
   add_edge_to_graph(attr1, attr2, cond, dep, aug_graph);
+}
+
+/**
+ * Combines dependencies for edgeset
+ * @param es edgeset
+ * @return combined dependencies given an edgeset
+ */
+DEPENDENCY get_edgeset_combine_dependencies(EDGESET es)
+{
+  DEPENDENCY acc_dependency = no_dependency;
+  for (; es != NULL; es = es->rest)
+  {
+    acc_dependency |= es->kind;
+  }
+
+  return acc_dependency;
 }
 
 /**
@@ -712,14 +733,192 @@ static void add_up_down_attributes(STATE *s, bool direction)
 }
 
 
+
+
+
+
+
+
+
+
+
+static bool is_inside_some_function(Declaration decl, Declaration *func)
+{
+  void *current = decl;
+  Declaration current_decl;
+  while (current != NULL && (current = tnode_parent(current)) != NULL)
+  {
+    switch (ABSTRACT_APS_tnode_phylum(current))
+    {
+    case KEYDeclaration:
+      current_decl = (Declaration)current;
+      switch (Declaration_KEY(current_decl))
+      {
+      case KEYsome_function_decl:
+        *func = current_decl;
+        return some_function_decl_result(current_decl) == decl;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * This function determines whether attribute instance should be considered for circularity check
+ * @param instance attribute instance
+ * @return true if instance not is not: If, Match and some formal
+ * @return false everything else
+ */
+static bool instance_can_be_considered_for_circularity_check(INSTANCE *instance)
+{
+  // If and Match statements can show up in a cycle but are never declared circular or non-circular
+  if (if_rule_p(instance->fibered_attr.attr))
+    return false;
+
+  Declaration node = instance->fibered_attr.attr;
+  Declaration func = NULL;
+
+  // The result in a function/procedure may show up in a cycle but are never declared circular or non-circular
+  if (is_inside_some_function(node, &func) && some_function_decl_result(func) == node)
+    return false;
+
+  if (instance->fibered_attr.fiber != NULL)
+    return false;
+
+  // Formals may show up in a cycle as well
+  switch (ABSTRACT_APS_tnode_phylum(node))
+  {
+  case KEYDeclaration:
+  {
+    switch (Declaration_KEY(node))
+    {
+    case KEYformal:
+      return false;
+    }
+  }
+  }
+
+  return true;
+}
+
+/**
+ * Ensure that attributes that participate in a cycle are defined circular
+ * @param s Analysis state
+ */
+static void assert_circular_declaration(STATE* s) {
+  int i, j, k;
+
+  // Forall phylum in the phylum_graph
+  for (i = 0; i < s->phyla.length; i++) {
+    PHY_GRAPH* phy = &s->phy_graphs[i];
+    int n = phy->instances.length;
+    int phylum_index = phylum_instance_start[i];
+    INSTANCE* array = phy->instances.array;
+
+    for (j = 0; j < n; j++) {
+      INSTANCE* instance = &array[j];
+      Declaration node = instance->fibered_attr.attr;
+
+      if (!instance_can_be_considered_for_circularity_check(instance))
+        continue;
+
+      bool any_cycle = false;
+      bool declared_circular = instance_circular(instance);
+
+      char instance_to_str[BUFFER_SIZE];
+      FILE* f = fmemopen(instance_to_str, sizeof(instance_to_str), "w");
+      print_instance(instance, f);
+      fclose(f);
+
+      for (k = 0; k < num_instances; k++) {
+        if (parent_index[k] == k) {
+          if (parent_index[phylum_index + j] == k) {
+            if (declared_circular) {
+              any_cycle = true;
+            } else {
+              aps_error(node,
+                        "Phylum graph (%s) instance (%s) involves in a cycle "
+                        "but it is not "
+                        "declared circular.",
+                        phy_graph_name(phy), instance_to_str);
+            }
+          }
+        }
+      }
+
+      if (declared_circular && !any_cycle) {
+        aps_warning(node,
+                    "Phylum graph (%s) instance (%s) is declared circular but "
+                    "does not involve "
+                    "in any cycle.",
+                    phy_graph_name(phy), instance_to_str);
+      }
+    }
+  }
+
+  // Forall edges in the augmented dependency graph
+  for (i = 0; i <= s->match_rules.length; i++) {
+    AUG_GRAPH* aug_graph = (i == s->match_rules.length)
+                               ? &s->global_dependencies
+                               : &s->aug_graphs[i];
+    int n = aug_graph->instances.length;
+    int constructor_index = constructor_instance_start[i];
+    INSTANCE* array = aug_graph->instances.array;
+    for (j = 0; j < n; j++) {
+      INSTANCE* instance = &array[j];
+      Declaration node = instance->fibered_attr.attr;
+
+      if (!instance_can_be_considered_for_circularity_check(instance))
+        continue;
+
+      bool any_cycle = false;
+      bool declared_circular = instance_circular(instance);
+
+      char instance_to_str[BUFFER_SIZE];
+      FILE* f = fmemopen(instance_to_str, sizeof(instance_to_str), "w");
+      print_instance(instance, f);
+      fclose(f);
+
+      // Forall cycles in the graph
+      for (k = 0; k < num_instances; k++) {
+        if (parent_index[k] == k) {
+          if (parent_index[constructor_index + j] == k) {
+            if (declared_circular) {
+              any_cycle = true;
+            } else {
+              aps_error(node,
+                        "Augmented graph (%s) instance (%s) involves in a "
+                        "cycle but it is not "
+                        "declared circular.",
+                        aug_graph_name(aug_graph), instance_to_str);
+            }
+          }
+        }
+      }
+      if (declared_circular && !any_cycle) {
+        aps_warning(node,
+                    "Augmented graph (%s) instance (%s) is declared circular "
+                    "but does not involve "
+                    "in any cycle.",
+                    aug_graph_name(aug_graph), instance_to_str);
+      }
+    }
+  }
+}
+
 void break_fiber_cycles(Declaration module,STATE *s,DEPENDENCY dep) {
   void *mark = SALLOC(0);
   init_indices(s);
   make_cycles(s);
   get_fiber_cycles(s);
+  assert_circular_declaration(s);
 
-  bool direction = !(dep & DEPENDENCY_NOT_JUST_FIBER);
-  add_up_down_attributes(s,direction);
+  // If there is just fiber cycles then we do up/down
+  if (!(dep & DEPENDENCY_NOT_JUST_FIBER))
+  {
+    add_up_down_attributes(s,UP_DOWN);
+  }
   release(mark);
   {
     int saved_analysis_debug = analysis_debug;
@@ -742,7 +941,3 @@ void break_fiber_cycles(Declaration module,STATE *s,DEPENDENCY dep) {
     print_analysis_state(s,stdout);
   }
 }
-
-  
-
-

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -913,7 +913,7 @@ void break_fiber_cycles(Declaration module,STATE *s,DEPENDENCY dep) {
   get_fiber_cycles(s);
   assert_circular_declaration(s);
 
-  // Preserve UP-DOWN edges if there accumulated dependency is just fiber cycle,
+  // Preserve UP-DOWN edges if the accumulated dependency is just fiber cycle,
   // otherwise preserve DOWN-UP edges.
   bool direction = !(dep & DEPENDENCY_NOT_JUST_FIBER) ? UP_DOWN : DOWN_UP;
   add_up_down_attributes(s,direction);

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -752,6 +752,8 @@ static bool is_inside_some_function(Declaration decl, Declaration *func)
       case KEYsome_function_decl:
         *func = current_decl;
         return some_function_decl_result(current_decl) == decl;
+      default:
+        break;
       }
       default:
         break;
@@ -796,6 +798,8 @@ static bool applicable_for_circularity_check(INSTANCE *instance)
       break;
     }
   }
+  default:
+    break;
   }
 
   return true;

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -10,6 +10,7 @@
 #include "aps-ag.h"
 
 int cycle_debug = 0;
+static const int BUFFER_SIZE = 1000;
 
 /* We use a union-find algorithm to detect strongly connected components.
  * We use a dynamically allocated array to hold the pointers,
@@ -413,20 +414,6 @@ static void edgeset_combine_dependencies(EDGESET es, DEPENDENCY* acc_dependency,
     acc_cond->positive |= es->cond.positive;
     acc_cond->negative |= es->cond.negative;
   }
-}
-
-/**
- * Combines dependencies for edgeset
- * @param es edgeset
- * @return combined dependencies given an edgeset
- */
-DEPENDENCY get_edgeset_combine_dependencies(EDGESET es)
-{
-  DEPENDENCY acc_dependency = no_dependency;
-  CONDITION acc_cond = { 0, 0 };
-  edgeset_combine_dependencies(es, &acc_dependency, &acc_cond);
-
-  return acc_dependency;
 }
 
 #define UP_DOWN_DIRECTION(v, direction) (direction ? v : !v)
@@ -841,10 +828,9 @@ static void assert_circular_declaration(STATE* s) {
               any_cycle = true;
             } else {
               aps_error(node,
-                        "Phylum graph (%s) instance (%s) involves in a cycle "
-                        "but it is not "
+                        "Instance (%s) involves in a cycle but it is not "
                         "declared circular.",
-                        phy_graph_name(phy), instance_to_str);
+                        instance_to_str);
             }
           }
         }
@@ -852,10 +838,9 @@ static void assert_circular_declaration(STATE* s) {
 
       if (declared_circular && !any_cycle) {
         aps_warning(node,
-                    "Phylum graph (%s) instance (%s) is declared circular but "
-                    "does not involve "
+                    "Instance (%s) is declared circular but does not involve "
                     "in any cycle.",
-                    phy_graph_name(phy), instance_to_str);
+                    instance_to_str);
       }
     }
   }
@@ -891,20 +876,18 @@ static void assert_circular_declaration(STATE* s) {
               any_cycle = true;
             } else {
               aps_error(node,
-                        "Augmented graph (%s) instance (%s) involves in a "
-                        "cycle but it is not "
+                        "Instance (%s) involves in a cycle but it is not "
                         "declared circular.",
-                        aug_graph_name(aug_graph), instance_to_str);
+                        instance_to_str);
             }
           }
         }
       }
       if (declared_circular && !any_cycle) {
         aps_warning(node,
-                    "Augmented graph (%s) instance (%s) is declared circular "
-                    "but does not involve "
+                    "Instance (%s) is declared circular but does not involve "
                     "in any cycle.",
-                    aug_graph_name(aug_graph), instance_to_str);
+                    instance_to_str);
       }
     }
   }

--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -913,6 +913,8 @@ void break_fiber_cycles(Declaration module,STATE *s,DEPENDENCY dep) {
   get_fiber_cycles(s);
   assert_circular_declaration(s);
 
+  // Preserve UP-DOWN edges if there accumulated dependency is just fiber cycle,
+  // otherwise preserve DOWN-UP edges.
   bool direction = !(dep & DEPENDENCY_NOT_JUST_FIBER) ? UP_DOWN : DOWN_UP;
   add_up_down_attributes(s,direction);
   release(mark);

--- a/analyze/aps-debug.c
+++ b/analyze/aps-debug.c
@@ -119,6 +119,7 @@ void set_debug_flags(const char *options)
     case 'U': cycle_debug |= PRINT_UP_DOWN; break;
     case 'o': oag_debug |= DEBUG_ORDER; break;
     case 'O': oag_debug |= TOTAL_ORDER; break;
+    case 'v': oag_debug |= DEBUG_ORDER_VERBOSE; break;
     case 'T': oag_debug |= PROD_ORDER; break;
     case '3': oag_debug |= TYPE_3_DEBUG; break;
     }

--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -1049,7 +1049,7 @@ static BOOL decl_is_collection(Declaration d) {
   }
 }
 
-static BOOL decl_is_circular(Declaration d)
+BOOL decl_is_circular(Declaration d)
 {
   if (!d) return FALSE;
   switch (Declaration_KEY(d)) {
@@ -2971,4 +2971,35 @@ void print_cycles(STATE *s, FILE *stream) {
       }
     }
   }
+}
+
+/**
+ * Utility function that determines whether fibered attribute is circular or not.
+ * if a fiber_attr is circular, which is true if the fiber is empty and the attribute
+ * (local or node attribute) is declared circular, OR (if the fiber is non-empty) if
+ * the last step in the fiber is circular.
+ * Note that a.b.c. is repsented as short = a.b, field = c 
+ * @param fiber_attr fibered attribute pointer
+ * @return boolean indicating the circularity 
+ */
+BOOL fiber_attr_circular(FIBERED_ATTRIBUTE* fiber_attr)
+{
+  // If fiber is empty
+  if (fiber_attr->fiber == base_fiber || fiber_attr->fiber == NULL)
+  {
+    return decl_is_circular(fiber_attr->attr);
+  }
+
+  FIBER fiber = fiber_attr->fiber;
+  return decl_is_circular(fiber->field);
+}
+
+/**
+ * Utility function indicating whether INSTANCE (attribute instance) is circular or not
+ * @param in attribute instance
+ * @return boolean indicating the circularity 
+ */
+BOOL instance_circular(INSTANCE* in)
+{
+  return fiber_attr_circular(&in->fibered_attr);
 }

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -25,6 +25,9 @@ enum instance_direction {instance_local, instance_inward, instance_outward};
 enum instance_direction fibered_attr_direction(FIBERED_ATTRIBUTE *fa);
 enum instance_direction instance_direction(INSTANCE *);
 
+extern BOOL fiber_attr_circular(FIBERED_ATTRIBUTE* fiber_attr);
+extern BOOL instance_circular(INSTANCE* in);
+
 typedef unsigned DEPENDENCY;
 
 #define SOME_DEPENDENCY 1
@@ -132,6 +135,8 @@ extern void print_edge_helper(DEPENDENCY, CONDITION *, FILE*);
 extern void print_edgeset(EDGESET, FILE *);
 extern void print_analysis_state(STATE *, FILE *);
 extern void print_cycles(STATE *, FILE *);
+
+extern BOOL decl_is_circular(Declaration d);
 
 extern int analysis_debug;
 #define ADD_EDGE 16

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -3,6 +3,7 @@
 
 #include "jbb-vector.h"
 #include "scc.h"
+#include <stdbool.h>
 
 typedef struct attrset {
   struct attrset *rest;
@@ -74,8 +75,8 @@ typedef struct augmented_dependency_graph {
   struct augmented_dependency_graph *next_in_aug_worklist;
   int *schedule; /* one-d array, indexed by instance number */
   struct cto_node *total_order;
-  SCC_COMPONENTS components;
-  bool* component_cycle;
+  SCC_COMPONENTS components;  /* SCC components of instances in augmented dependency graph */
+  bool* component_cycle;      /* boolean indicating whether SCC component at index is circular */
 } AUG_GRAPH;
 extern const char *aug_graph_name(AUG_GRAPH *);
 
@@ -85,8 +86,8 @@ typedef struct summary_dependency_graph {
   VECTOR(INSTANCE) instances;
   DEPENDENCY *mingraph; /* two-d array, indexed by instance number */
   struct summary_dependency_graph *next_in_phy_worklist;
-  SCC_COMPONENTS components;
-  bool* component_cycle;
+  SCC_COMPONENTS components;  /* SCC components of instances in phylum graph */
+  bool* component_cycle;      /* boolean indicating whether SCC component at index is circular */
   int *summary_schedule; /* one-d array, indexed by instance number */
 } PHY_GRAPH;
 extern const char *phy_graph_name(PHY_GRAPH *);

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -2,6 +2,7 @@
 #define APS_DNC_H
 
 #include "jbb-vector.h"
+#include "scc.h"
 
 typedef struct attrset {
   struct attrset *rest;
@@ -73,6 +74,8 @@ typedef struct augmented_dependency_graph {
   struct augmented_dependency_graph *next_in_aug_worklist;
   int *schedule; /* one-d array, indexed by instance number */
   struct cto_node *total_order;
+  SCC_COMPONENTS components;
+  bool* component_cycle;
 } AUG_GRAPH;
 extern const char *aug_graph_name(AUG_GRAPH *);
 
@@ -82,10 +85,12 @@ typedef struct summary_dependency_graph {
   VECTOR(INSTANCE) instances;
   DEPENDENCY *mingraph; /* two-d array, indexed by instance number */
   struct summary_dependency_graph *next_in_phy_worklist;
+  SCC_COMPONENTS components;
+  bool* component_cycle;
   int *summary_schedule; /* one-d array, indexed by instance number */
 } PHY_GRAPH;
 extern const char *phy_graph_name(PHY_GRAPH *);
-  
+
 typedef VECTOR(struct cycle_description) CYCLES;
 
 typedef struct analysis_state {

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -75,7 +75,7 @@ typedef struct augmented_dependency_graph {
   struct augmented_dependency_graph *next_in_aug_worklist;
   int *schedule; /* one-d array, indexed by instance number */
   struct cto_node *total_order;
-  SCC_COMPONENTS components;  /* SCC components of instances in augmented dependency graph */
+  SCC_COMPONENTS* components; /* SCC components of instances in augmented dependency graph */
   bool* component_cycle;      /* boolean indicating whether SCC component at index is circular */
 } AUG_GRAPH;
 extern const char *aug_graph_name(AUG_GRAPH *);
@@ -86,7 +86,7 @@ typedef struct summary_dependency_graph {
   VECTOR(INSTANCE) instances;
   DEPENDENCY *mingraph; /* two-d array, indexed by instance number */
   struct summary_dependency_graph *next_in_phy_worklist;
-  SCC_COMPONENTS components;  /* SCC components of instances in phylum graph */
+  SCC_COMPONENTS* components; /* SCC components of instances in phylum graph */
   bool* component_cycle;      /* boolean indicating whether SCC component at index is circular */
   int *summary_schedule; /* one-d array, indexed by instance number */
 } PHY_GRAPH;

--- a/analyze/aps-dnc.h
+++ b/analyze/aps-dnc.h
@@ -27,6 +27,7 @@ enum instance_direction instance_direction(INSTANCE *);
 
 extern BOOL fiber_attr_circular(FIBERED_ATTRIBUTE* fiber_attr);
 extern BOOL instance_circular(INSTANCE* in);
+extern BOOL decl_is_circular(Declaration d);
 
 typedef unsigned DEPENDENCY;
 
@@ -135,8 +136,6 @@ extern void print_edge_helper(DEPENDENCY, CONDITION *, FILE*);
 extern void print_edgeset(EDGESET, FILE *);
 extern void print_analysis_state(STATE *, FILE *);
 extern void print_cycles(STATE *, FILE *);
-
-extern BOOL decl_is_circular(Declaration d);
 
 extern int analysis_debug;
 #define ADD_EDGE 16

--- a/analyze/aps-info.h
+++ b/analyze/aps-info.h
@@ -69,6 +69,7 @@ struct Declaration_info {
 };
 extern struct Declaration_info *Declaration_info(Declaration);
 
+#define DECL_PHY_GRAPH(decl) (Declaration_info(decl)->node_phy_graph)
 #define DECL_NEXT(decl) (Declaration_info(decl)->next_decl)
 #define NEXT_FIELD(decl) (Declaration_info(decl)->next_field_decl)
 #define DUAL_DECL(decl) (Declaration_info(decl)->dual_decl)

--- a/analyze/aps-oag.h
+++ b/analyze/aps-oag.h
@@ -23,12 +23,18 @@ struct cto_node {
   CTO_NODE* cto_if_true;
 #define cto_if_false cto_next
 };
-      
+
 extern int oag_debug;
 #define TOTAL_ORDER 1
 #define DEBUG_ORDER 2
 #define PROD_ORDER 4
 #define PROD_ORDER_DEBUG 8
 #define TYPE_3_DEBUG 16
+#define DEBUG_ORDER_VERBOSE 32
+
+#define CONDITION_IS_IMPOSSIBLE(cond) ((cond).positive & (cond).negative)
+#define MERGED_CONDITION_IS_IMPOSSIBLE(cond1, cond2) (((cond1).positive|(cond2).positive) & ((cond1).negative|(cond2).negative))
+
+CONDITION instance_condition(INSTANCE *in);
 
 #endif

--- a/analyze/aps-scc.c
+++ b/analyze/aps-scc.c
@@ -23,10 +23,10 @@ void set_phylum_graph_components(PHY_GRAPH* phy_graph) {
 
   phy_graph->components = scc_graph_components(graph);
   phy_graph->component_cycle =
-      (bool*)calloc(sizeof(bool), phy_graph->components.length);
+      (bool*)calloc(sizeof(bool), phy_graph->components->length);
 
-  for (i = 0; i < phy_graph->components.length; i++) {
-    SCC_COMPONENT* comp = &phy_graph->components.array[i];
+  for (i = 0; i < phy_graph->components->length; i++) {
+    SCC_COMPONENT* comp = phy_graph->components->array[i];
 
     for (j = 0; j < comp->length; j++) {
       INSTANCE* in = (INSTANCE*)comp->array[j];
@@ -39,8 +39,8 @@ void set_phylum_graph_components(PHY_GRAPH* phy_graph) {
 
   if ((oag_debug & DEBUG_ORDER) && (oag_debug & DEBUG_ORDER_VERBOSE)) {
     printf("Components of Phylum Graph: %s\n", phy_graph_name(phy_graph));
-    for (j = 0; j < phy_graph->components.length; j++) {
-      SCC_COMPONENT* comp = &phy_graph->components.array[j];
+    for (j = 0; j < phy_graph->components->length; j++) {
+      SCC_COMPONENT* comp = phy_graph->components->array[j];
       printf(" Component #%d [%s]\n", j,
              phy_graph->component_cycle[j] ? "circular" : "non-circular");
 
@@ -74,10 +74,10 @@ void set_aug_graph_components(AUG_GRAPH* aug_graph) {
 
   aug_graph->components = scc_graph_components(graph);
   aug_graph->component_cycle =
-      (bool*)calloc(sizeof(bool), aug_graph->components.length);
+      (bool*)calloc(sizeof(bool), aug_graph->components->length);
 
-  for (i = 0; i < aug_graph->components.length; i++) {
-    SCC_COMPONENT* comp = &aug_graph->components.array[i];
+  for (i = 0; i < aug_graph->components->length; i++) {
+    SCC_COMPONENT* comp = aug_graph->components->array[i];
 
     for (j = 0; j < comp->length; j++) {
       INSTANCE* source = (INSTANCE*)comp->array[j];
@@ -93,8 +93,8 @@ void set_aug_graph_components(AUG_GRAPH* aug_graph) {
 
   if ((oag_debug & DEBUG_ORDER) && (oag_debug & DEBUG_ORDER_VERBOSE)) {
     printf("Components of Augmented Graph: %s\n", aug_graph_name(aug_graph));
-    for (j = 0; j < aug_graph->components.length; j++) {
-      SCC_COMPONENT* comp = &aug_graph->components.array[j];
+    for (j = 0; j < aug_graph->components->length; j++) {
+      SCC_COMPONENT* comp = aug_graph->components->array[j];
       printf(" Component #%d [%s]\n", j,
              aug_graph->component_cycle[j] ? "circular" : "non-circular");
 

--- a/analyze/aps-scc.c
+++ b/analyze/aps-scc.c
@@ -8,20 +8,28 @@
 void set_phylum_graph_components(PHY_GRAPH* phy_graph) {
   int i, j, k;
   int n = phy_graph->instances.length;
-  SccGraph* graph;
-  scc_graph_initialize(graph, n);
+  SccGraph graph;
+  scc_graph_initialize(&graph, n);
+
+  // Add vertices
+  for (i = 0; i < n; i++) {
+    INSTANCE* in = &phy_graph->instances.array[i];
+    scc_graph_add_vertex(&graph, (void*)in);
+  }
+
+  // Add edges
   for (i = 0; i < n; i++) {
     INSTANCE* source = &phy_graph->instances.array[i];
     for (j = 0; j < n; j++) {
       if (phy_graph->mingraph[i * n + j]) {
         INSTANCE* sink = &phy_graph->instances.array[j];
 
-        scc_graph_add_edge(graph, (void*)source, (void*)sink);
+        scc_graph_add_edge(&graph, (void*)source, (void*)sink);
       }
     }
   }
 
-  phy_graph->components = scc_graph_components(graph);
+  phy_graph->components = scc_graph_components(&graph);
   phy_graph->component_cycle =
       (bool*)calloc(sizeof(bool), phy_graph->components->length);
 

--- a/analyze/aps-scc.c
+++ b/analyze/aps-scc.c
@@ -65,8 +65,16 @@ void set_phylum_graph_components(PHY_GRAPH* phy_graph) {
 void set_aug_graph_components(AUG_GRAPH* aug_graph) {
   int i, j, k;
   int n = aug_graph->instances.length;
-  SccGraph* graph;
-  scc_graph_initialize(graph, n);
+  SccGraph graph;
+  scc_graph_initialize(&graph, n);
+
+  // Add vertices
+  for (i = 0; i < n; i++) {
+    INSTANCE* in = &aug_graph->instances.array[i];
+    scc_graph_add_vertex(&graph, (void*)in);
+  }
+
+  // Add edges
   for (i = 0; i < n; i++) {
     INSTANCE* source = &aug_graph->instances.array[i];
     for (j = 0; j < n; j++) {
@@ -74,13 +82,13 @@ void set_aug_graph_components(AUG_GRAPH* aug_graph) {
       if (edgeset_kind(aug_graph->graph[i * n + j])) {
         if (!MERGED_CONDITION_IS_IMPOSSIBLE(instance_condition(source),
                                             instance_condition(sink))) {
-          scc_graph_add_edge(graph, (void*)source, (void*)sink);
+          scc_graph_add_edge(&graph, (void*)source, (void*)sink);
         }
       }
     }
   }
 
-  aug_graph->components = scc_graph_components(graph);
+  aug_graph->components = scc_graph_components(&graph);
   aug_graph->component_cycle =
       (bool*)calloc(sizeof(bool), aug_graph->components->length);
 

--- a/analyze/aps-scc.c
+++ b/analyze/aps-scc.c
@@ -1,0 +1,109 @@
+#include <jbb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "aps-ag.h"
+#include "jbb-alloc.h"
+
+void set_phylum_graph_components(PHY_GRAPH* phy_graph) {
+  int i, j, k;
+  int n = phy_graph->instances.length;
+  SccGraph* graph;
+  scc_graph_initialize(graph, n);
+  for (i = 0; i < n; i++) {
+    INSTANCE* source = &phy_graph->instances.array[i];
+    for (j = 0; j < n; j++) {
+      if (phy_graph->mingraph[i * n + j]) {
+        INSTANCE* sink = &phy_graph->instances.array[j];
+
+        scc_graph_add_edge(graph, (void*)source, (void*)sink);
+      }
+    }
+  }
+
+  phy_graph->components = scc_graph_components(graph);
+  phy_graph->component_cycle =
+      (bool*)calloc(sizeof(bool), phy_graph->components.length);
+
+  for (i = 0; i < phy_graph->components.length; i++) {
+    SCC_COMPONENT* comp = &phy_graph->components.array[i];
+
+    for (j = 0; j < comp->length; j++) {
+      INSTANCE* in = (INSTANCE*)comp->array[j];
+
+      if (phy_graph->mingraph[in->index * n + in->index]) {
+        phy_graph->component_cycle[i] = true;
+      }
+    }
+  }
+
+  if ((oag_debug & DEBUG_ORDER) && (oag_debug & DEBUG_ORDER_VERBOSE)) {
+    printf("Components of Phylum Graph: %s\n", phy_graph_name(phy_graph));
+    for (j = 0; j < phy_graph->components.length; j++) {
+      SCC_COMPONENT* comp = &phy_graph->components.array[j];
+      printf(" Component #%d [%s]\n", j,
+             phy_graph->component_cycle[j] ? "circular" : "non-circular");
+
+      for (k = 0; k < comp->length; k++) {
+        printf("   ");
+        print_instance(comp->array[k], stdout);
+        printf("\n");
+      }
+    }
+    printf("\n");
+  }
+}
+
+void set_aug_graph_components(AUG_GRAPH* aug_graph) {
+  int i, j, k;
+  int n = aug_graph->instances.length;
+  SccGraph* graph;
+  scc_graph_initialize(graph, n);
+  for (i = 0; i < n; i++) {
+    INSTANCE* source = &aug_graph->instances.array[i];
+    for (j = 0; j < n; j++) {
+      INSTANCE* sink = &aug_graph->instances.array[j];
+      if (edgeset_kind(aug_graph->graph[i * n + j])) {
+        if (!MERGED_CONDITION_IS_IMPOSSIBLE(instance_condition(source),
+                                            instance_condition(sink))) {
+          scc_graph_add_edge(graph, (void*)source, (void*)sink);
+        }
+      }
+    }
+  }
+
+  aug_graph->components = scc_graph_components(graph);
+  aug_graph->component_cycle =
+      (bool*)calloc(sizeof(bool), aug_graph->components.length);
+
+  for (i = 0; i < aug_graph->components.length; i++) {
+    SCC_COMPONENT* comp = &aug_graph->components.array[i];
+
+    for (j = 0; j < comp->length; j++) {
+      INSTANCE* source = (INSTANCE*)comp->array[j];
+
+      for (k = 0; k < comp->length; k++) {
+        INSTANCE* sink = (INSTANCE*)comp->array[k];
+        if (edgeset_kind(aug_graph->graph[source->index * n + sink->index])) {
+          aug_graph->component_cycle[i] = true;
+        }
+      }
+    }
+  }
+
+  if ((oag_debug & DEBUG_ORDER) && (oag_debug & DEBUG_ORDER_VERBOSE)) {
+    printf("Components of Augmented Graph: %s\n", aug_graph_name(aug_graph));
+    for (j = 0; j < aug_graph->components.length; j++) {
+      SCC_COMPONENT* comp = &aug_graph->components.array[j];
+      printf(" Component #%d [%s]\n", j,
+             aug_graph->component_cycle[j] ? "circular" : "non-circular");
+
+      for (k = 0; k < comp->length; k++) {
+        printf("   ");
+        print_instance((INSTANCE*)comp->array[k], stdout);
+        printf("\n");
+      }
+    }
+    printf("\n");
+  }
+}

--- a/analyze/aps-scc.h
+++ b/analyze/aps-scc.h
@@ -1,0 +1,8 @@
+#ifndef APS_SCC_H
+#define APS_SCC_H
+
+void set_phylum_graph_components(PHY_GRAPH* phy_graph);
+
+void set_aug_graph_components(AUG_GRAPH* aug_graph);
+
+#endif

--- a/analyze/aps-scc.h
+++ b/analyze/aps-scc.h
@@ -4,13 +4,13 @@
 #include "aps-dnc.h"
 
 /**
- * @brief sets phylum graph SCC components
+ * @brief sets phylum graph SCC components of instances
  * @param phy_graph phylum graph
  */
 void set_phylum_graph_components(PHY_GRAPH* phy_graph);
 
 /**
- * @brief sets augmented dependency graph SCC components
+ * @brief sets augmented dependency graph SCC components of instances
  * @param aug_graph augmented dependency graph
  */
 void set_aug_graph_components(AUG_GRAPH* aug_graph);

--- a/analyze/aps-scc.h
+++ b/analyze/aps-scc.h
@@ -1,8 +1,18 @@
 #ifndef APS_SCC_H
 #define APS_SCC_H
 
+#include "aps-dnc.h"
+
+/**
+ * @brief sets phylum graph SCC components
+ * @param phy_graph phylum graph
+ */
 void set_phylum_graph_components(PHY_GRAPH* phy_graph);
 
+/**
+ * @brief sets augmented dependency graph SCC components
+ * @param aug_graph augmented dependency graph
+ */
 void set_aug_graph_components(AUG_GRAPH* aug_graph);
 
 #endif

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -5,7 +5,6 @@
 #include "aps-ag.h"
 
 int type_debug = FALSE;
-static const int BUFFER_SIZE = 1000;
 
 static Type Boolean_Type;
 static Type Integer_Type;
@@ -377,6 +376,7 @@ static char* trim_string_const_token(char* p) {
 }
 
 static void* validate_canonicals(void* ignore, void*node) {
+  int BUFFER_SIZE = 1000;
   Symbol symb_test_canonical_type = intern_symbol("test_canonical_type");
   Symbol symb_test_canonical_base_type = intern_symbol("test_canonical_base_type");
   Symbol symb_test_canonical_signature = intern_symbol("test_canonical_signature");

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -188,6 +188,8 @@ static void* do_typechecking(void* ignore, void*node) {
 	      }
 	    }
 	    break;
+    default:
+      break;
 	  }
 	}
 	/* FALL THROUGH */
@@ -300,6 +302,8 @@ static void* do_typechecking(void* ignore, void*node) {
 	  (void)check_actuals(type_inst_actuals(ty),fty,u);
 	}
 	return 0;
+      default:
+        break;
       }
     }
     break;
@@ -425,8 +429,12 @@ static void* validate_canonicals(void* ignore, void*node) {
         }
       }
     }
+    default:
+      break;
     }
   }
+  default:
+    break;
   }
   return node;
 }
@@ -456,8 +464,12 @@ static void* set_root_phylum(void *ignore, void *node)
 
       return NULL;
     }
+    default:
+      break;
     }
   }
+  default:
+    break;
   }
 
   return node;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -5,7 +5,7 @@
 #include "aps-ag.h"
 
 int type_debug = FALSE;
-int BUFFER_SIZE = 1000;
+static const int BUFFER_SIZE = 1000;
 
 static Type Boolean_Type;
 static Type Integer_Type;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -5,6 +5,7 @@
 #include "aps-ag.h"
 
 int type_debug = FALSE;
+int BUFFER_SIZE = 1000;
 
 static Type Boolean_Type;
 static Type Integer_Type;
@@ -372,7 +373,6 @@ static char* trim_string_const_token(char* p) {
 }
 
 static void* validate_canonicals(void* ignore, void*node) {
-  int BUFFER_SIZE = 1000;
   Symbol symb_test_canonical_type = intern_symbol("test_canonical_type");
   Symbol symb_test_canonical_base_type = intern_symbol("test_canonical_base_type");
   Symbol symb_test_canonical_signature = intern_symbol("test_canonical_signature");

--- a/analyze/aps-type.h
+++ b/analyze/aps-type.h
@@ -94,4 +94,6 @@ void print_Signature(Signature,FILE*);
 
 extern int type_debug;
 
+extern int BUFFER_SIZE;
+
 #endif

--- a/analyze/aps-type.h
+++ b/analyze/aps-type.h
@@ -94,6 +94,4 @@ void print_Signature(Signature,FILE*);
 
 extern int type_debug;
 
-extern int BUFFER_SIZE;
-
 #endif

--- a/analyze/canonical-signature.c
+++ b/analyze/canonical-signature.c
@@ -384,8 +384,6 @@ static CanonicalSignatureSet from_type(Type t)
 {
   switch (Type_KEY(t))
   {
-  case KEYtype_formal:
-    return get_hash_cons_empty_set();
   case KEYtype_use:
     return infer_canonical_signatures(canonical_type(t));
   case KEYtype_inst:
@@ -446,6 +444,8 @@ static CanonicalSignatureSet from_declaration(Declaration decl)
       re = substitute_canonical_signature_set_actuals(new_canonical_type_use(decl), re);
       break;
     }
+    default:
+      break;
     }
     break;
   }
@@ -520,6 +520,9 @@ static CanonicalSignature* join_canonical_signature_actuals(CanonicalType *sourc
 
     return new_canonical_signature(canonical_sig->is_input, canonical_sig->is_var, canonical_sig->source_class, canonical_sig->num_actuals, substituted_actuals);
   }
+  default:
+    fatal_error("Unexpected source canonical type with key of %d", source_ctype->key);
+    return NULL;
   }
 }
 
@@ -593,6 +596,9 @@ static CanonicalSignature *substitute_canonical_signature_actuals(CanonicalType 
 
     return new_canonical_signature(canonical_sig->is_input, canonical_sig->is_var, canonical_sig->source_class, canonical_sig->num_actuals, substituted_actuals);
   }
+  default:
+    fatal_error("Unexpected source canonical type with key of %d", source_ctype->key);
+    return NULL;
   }
 }
 
@@ -661,6 +667,8 @@ CanonicalSignatureSet infer_canonical_signatures(CanonicalType *ctype)
       flag = false;
       break;
     }
+    default:
+      break;
     }
 
     // TODO: lets revisit this 12/14/2020

--- a/analyze/canonical-type.c
+++ b/analyze/canonical-type.c
@@ -325,7 +325,11 @@ static bool is_some_result_decl(Declaration decl)
       {
       case KEYmodule_decl:
         return some_class_decl_result_type(current_decl) == decl;
+      default:
+        break;
       }
+    default:
+      break;
     }
   }
 
@@ -558,6 +562,8 @@ CanonicalType *canonical_type_base_type(CanonicalType *ctype)
           return canonical_type_join(new_canonical_type_use(decl), canonical_type_base_type(new_canonical_type_use(some_class_decl_result_type(mdecl))), true);
         }
       }
+      default:
+        break;
       }
     }
     default:
@@ -597,8 +603,12 @@ CanonicalType *canonical_type_base_type(CanonicalType *ctype)
           return canonical_type_join(ctype_qual->source, canonical_type_join(new_canonical_type_use(decl), canonical_type_base_type(new_canonical_type_use(some_class_decl_result_type(mdecl))), true), true);
         }
       }
+      default:
+        break;
       }
     }
+    default:
+      break;
     }
   }
   case KEY_CANONICAL_FUNC:
@@ -620,6 +630,7 @@ CanonicalType *canonical_type_base_type(CanonicalType *ctype)
   }
   default:
     fatal_error("canonical_type_base_type failed");
+    return NULL;
   }
 }
 
@@ -985,6 +996,7 @@ CanonicalType *canonical_type_join(CanonicalType *ctype_outer, CanonicalType *ct
     }
   default:
     fatal_error("canonical_type_join failed");
+    return NULL;
   }
 }
 

--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -514,5 +514,3 @@ class PatternSeqFunction[R,A](f : Any => Option[(R,Seq[A])]) {
 object P_AND {
   def unapply[T](x : T) : Option[(T,T)] = Some((x,x));
 }
-
-

--- a/parse/aps-tree-dump.handcode.i
+++ b/parse/aps-tree-dump.handcode.i
@@ -1,5 +1,5 @@
 void dump_lisp_Symbol(Symbol s) {
-  char *name = symbol_name(s);
+  const char *name = symbol_name(s);
   printf(" aps-boot::|");
   while (*name != '\0') {
     switch (*name) {

--- a/parse/string.c
+++ b/parse/string.c
@@ -26,7 +26,7 @@ struct special_string {
 
 #define AS_SPECIAL(p,x) struct special_string *p=(struct special_string *)(x)
 
-#define CONSTANT_STRING (128+'+')
+#define CONSTANT_STRING (((unsigned char)(128+(unsigned char)'+')))
 struct constant_string {
   struct special_string header;
   char *value;
@@ -34,7 +34,7 @@ struct constant_string {
 #define AS_CONSTANT(p,x) \
   struct constant_string *p=(struct constant_string *)(x)
 
-#define CONC_STRING (128+')')
+#define CONC_STRING (((unsigned char)(128+(unsigned char)')')))
 struct conc_string {
   struct special_string header;
   STRING str1, str2;


### PR DESCRIPTION
- all compiler warnings are fixed (tested with clang and GCC) 
- introduced new `aps-scc` that finds strongly connected components of instances in phylum and augmented dependency graph
- code to make sure instances that involve in a cycle is declared circular 
- removed `KEYtype_formal` in `canonical-signature` because its an enum of declaration type but mistakenly used in type key