### PR TITLE
Avoid silent error when opening a file in aps2scala

### DIFF
--- a/aps2scala/aps2scala.cc
+++ b/aps2scala/aps2scala.cc
@@ -95,8 +95,7 @@ int main(int argc,char **argv) {
     }
     char* outfilename = str2cat(argv[i],".scala");
 
-    std::ofstream out;
-    out.open(outfilename);
+    std::ofstream out(outfilename);
     if (out.fail())
     {
       std::cerr << "Failed to open output file " << outfilename << std::endl;

--- a/aps2scala/aps2scala.cc
+++ b/aps2scala/aps2scala.cc
@@ -95,8 +95,15 @@ int main(int argc,char **argv) {
     }
     char* outfilename = str2cat(argv[i],".scala");
 
-    std::ofstream out(outfilename);
+    std::ofstream out;
+    out.open(outfilename);
+    if (out.fail())
+    {
+      std::cerr << "Failed to open output file " << outfilename << std::endl;
+      exit(1);
+    }
     dump_scala_Program(p,out);
+    out.close();
   }
   exit(0);
 }


### PR DESCRIPTION
We need to close the filestream when we are done writing to the file