### PR TITLE
Fixed test cycle's test typo and added nullable test

### DIFF
--- a/examples/scala/test-cycle-driver.scala
+++ b/examples/scala/test-cycle-driver.scala
@@ -10,7 +10,7 @@ object TestCycleDriver extends App
 
     m.finish();
 
-    val m2 = new M_TEST_COLL("Test Cycle",m);
+    val m2 = new M_TEST_CYCLE("Test Cycle",m);
     val w2 = w.asInstanceOf[m2.T_Root];
 
     m2.finish();

--- a/examples/scala/test-cycle-driver.scala
+++ b/examples/scala/test-cycle-driver.scala
@@ -1,6 +1,6 @@
 object TestCycleDriver extends App
 {
-    val m = new M_TEST_CYCLE("Tiny");
+    val m = new M_TINY("Tiny");
     type T_Tiny = m.T_Result;
     val t_Tiny = m.t_Result;
 
@@ -10,5 +10,10 @@ object TestCycleDriver extends App
 
     m.finish();
 
-    println("leaves is " + t_Tiny.v_leaves);
+    val m2 = new M_TEST_COLL("Test Cycle",m);
+    val w2 = w.asInstanceOf[m2.T_Root];
+
+    m2.finish();
+
+    println("leaves is " + m2.v_leaves);
 }

--- a/examples/scala/tests/Makefile
+++ b/examples/scala/tests/Makefile
@@ -1,4 +1,4 @@
-SPECS=FirstSpec FollowSpec
+SPECS=FirstSpec FollowSpec NullableSpec
 EXAMPLES_PATH=../..
 ROOT_PATH=../${EXAMPLES_PATH}
 SCALAV=2.12
@@ -16,7 +16,7 @@ clean:
 %.class: %.scala
 	scalac -cp ${SCALA_FLAGS} $<
 
-first.scala follow.scala:
+first.scala follow.scala nullable.scala:
 	${APS2SCALA} -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base -S $(basename $(@F))
 
 %.scala:
@@ -33,3 +33,6 @@ FirstSpec.class: Spec.class GrammarUtil.class first.class
 
 FollowSpec.class: Spec.class GrammarUtil.class follow.class
 	scalac -cp ${SCALA_FLAGS} FollowSpec.scala
+
+NullableSpec.class: Spec.class GrammarUtil.class nullable.class
+	scalac -cp ${SCALA_FLAGS} NullableSpec.scala

--- a/examples/scala/tests/NullableSpec.scala
+++ b/examples/scala/tests/NullableSpec.scala
@@ -1,0 +1,29 @@
+object NullableSpec extends Spec {
+
+  import GrammarUtil._
+
+  def testBasic() = {
+    // Arrange
+    var map = List[(String, List[String])]()
+    map +:= ("Z", List("Y", "X"))
+    map +:= ("Y", List())
+    map +:= ("X", List())
+    map +:= ("A", List("Z", "a"))
+    map +:= ("B", List("b", "B"))
+    map +:= ("B", List())
+  
+    // Act
+    val first = new M_NULLABLE("Nullable", buildGrammar(map))
+    first.finish()
+
+    val nullableTable = (for ((key, value) <- first.v_nullableTable) yield (key.name, value)).toMap
+
+    // Assert
+    assertEquals(5, nullableTable.size, "Validate nullableTable size")
+    assertEquals(true, nullableTable("X"), "Validate nullable of X");
+    assertEquals(true, nullableTable("Y"), "Validate nullable of Y");
+    assertEquals(true, nullableTable("Z"), "Validate nullable of Z");
+    assertEquals(false, nullableTable("A"), "Validate nullable of A");
+    assertEquals(true, nullableTable("B"), "Validate nullable of B");
+  }
+}


### PR DESCRIPTION
We already had First and Follow tests. There is also `nullable.aps` (CRAG) that uses the same syntax tree so adding unit tests was very easy to do.

There was a small typo bug in `tests-cycle` and now its fixed.