### PR TITLE
Dockerized APS for teaching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:3.17 AS base
+
+LABEL maintainer="boyland@uwm.edu"
+LABEL version="1.0.0"
+
+ARG SCALA_VERSION="2.12.13"
+ARG BISON_VERSION="3.5.1"
+ARG CLASSHOME="/usr/local"
+
+WORKDIR /usr/lib
+
+# Install basics
+RUN apk add --no-cache bash make flex gcompat gcc g++ openjdk11 build-base m4 git ncurses \
+  && apk add --no-cache --virtual=build-dependencies wget ca-certificates
+
+# Download Scala
+RUN wget -q "https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz" -O - | gunzip | tar x
+
+ENV SCALAHOME="/usr/lib/scala-$SCALA_VERSION"
+ENV PATH="$SCALAHOME/bin:$PATH"
+
+# Build and install Bison
+RUN wget -q "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz" -O - | gunzip | tar x \
+  && cd "bison-${BISON_VERSION}" \
+  && ./configure \
+  && make \
+  && make install
+
+COPY . .
+
+ENV APSHOME="/usr/lib/bin"
+ENV PATH="$APSHOME:$PATH"
+
+WORKDIR /usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 SUBDIRS= utilities parse analyze aps2scala apscpp
+DOCKERTAG= boylanduwm/aps
+
 install:
 	-mkdir -p lib bin
 	for d in ${SUBDIRS}; do \
@@ -16,6 +18,12 @@ realclean:
 	for d in ${SUBDIRS}; do \
 	  (cd $$d; ${MAKE} realclean); \
 	done
+
+dockerbuild: install
+	sudo docker build . -t ${DOCKERTAG}
+
+dockerpush:
+	docker push ${DOCKERTAG}
 
 distclean: realclean
 	rm -rf bin lib


### PR DESCRIPTION
- correct version of Bison
- correct version of Scala
- `apssched` and `aps2scala` are available in the environment

To run:
```
docker run -v `pwd`:/root -it --rm -w /root <image-name> sh
```