### PR TITLE
Fix Scala 2.12 deprecations and tested on 2.13

### DIFF
--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -195,17 +195,17 @@ object Evaluation {
 
   class Stack[A](private var elems: List[A] = List.empty[A]) extends Iterable[A] {
     def push(v: A): Stack[A] = {
-      elems = v :: elems
-      this
+      elems = v :: elems;
+      this;
     }
 
     def pop(): A = {
       if (elems.isEmpty) {
-        throw new NoSuchElementException("Empty Stack")
+        throw new NoSuchElementException("Empty Stack");
       } else {
-        val popped = elems.head
-        elems = elems.tail
-        popped
+        val popped = elems.head;
+        elems = elems.tail;
+        popped;
       }
     }
 

--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -193,7 +193,24 @@ object Evaluation {
   case class CyclicAttributeException(w : String) extends APSException("cyclic attribute: " + w) {}
   object StubError extends APSException("stub error") {}
 
-  import scala.collection.mutable.Stack;
+  class Stack[A](private var elems: List[A] = List.empty[A]) extends Iterable[A] {
+    def push(v: A): Stack[A] = {
+      elems = v :: elems
+      this
+    }
+
+    def pop(): A = {
+      if (elems.isEmpty) {
+        throw new NoSuchElementException("Empty Stack")
+      } else {
+        val popped = elems.head
+        elems = elems.tail
+        popped
+      }
+    }
+
+    override def iterator: Iterator[A] = elems.iterator
+  }
 
   val pending : Stack[Evaluation[_,_]] = new Stack();
 }

--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -1295,7 +1295,7 @@ with C_STRING[String]
   override def f_assert(v__88 : T_Result) : Unit = {};
   
   val v__op_AC = f__op_AC _;
-  def f__op_AC(v_l : Char*):T_Result = (v_l :\ "")((c,s) => c + s);
+  def f__op_AC(v_l : Char*):T_Result = (v_l foldRight "")((c,s) => c + s);
   
   val p__op_AC = new PatternSeqFunction[T_Result,Char](u__op_AC);
   def u__op_AC(x:Any) : Option[(T_Result,Seq[Char])] = x match {

--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -769,7 +769,7 @@ with C_BAG[List[T_ElemType],T_ElemType]
   val v_none = f_none _;
   def f_none():T_Result = Nil;
   def u_none(x:Any) : Option[T_Result] = x match {
-    case x@Nil => Some((x));
+    case x@Nil => Some((x).asInstanceOf[T_Result]);
     case _ => None };
   val p_none = new PatternFunction[T_Result](u_none);
   


### PR DESCRIPTION
The following were the deprecation warnings when building APS `base/scala` folder.

```
scalac -deprecation aps-impl.scala basic.handcode.scala table.handcode.scala symbol.scala symbol.handcode.scala
aps-impl.scala:198: warning: class Stack in package mutable is deprecated (since 2.12.0): Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.
  val pending : Stack[Evaluation[_,_]] = new Stack();
                ^
aps-impl.scala:198: warning: class Stack in package mutable is deprecated (since 2.12.0): Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.
  val pending : Stack[Evaluation[_,_]] = new Stack();
                                             ^
basic.handcode.scala:1298: warning: method :\ in trait TraversableOnce is deprecated (since 2.12.10): Use foldRight instead of :\
  def f__op_AC(v_l : Char*):T_Result = (v_l :\ "")((c,s) => c + s)
```

Tested on Scala 2.13