### PR TITLE
Modified the examples and tests to use new -C flag for first/follow/nullable

### DIFF
--- a/examples/scala/Makefile
+++ b/examples/scala/Makefile
@@ -10,7 +10,7 @@ APS2SCALAFLAGS = -p ..:${APSTOP}/base -G
 
 SCALAGEN = simple.scala classic-binding.scala tiny.scala \
 	test-coll.scala test-use-coll.scala test-cycle.scala use-global.scala \
-	grammar.scala first.static.scala follow.static.scala nullable.static.scala
+	grammar.scala first.scala follow.scala nullable.scala
 
 MISCGEN = nested-cycles.scala GrammarParser.scala SimpleParser.scala \
 	GrammarTokens.scala SimpleTokens.scala *.scala~ GrammarScanner.scala \

--- a/examples/scala/Makefile
+++ b/examples/scala/Makefile
@@ -10,7 +10,7 @@ APS2SCALAFLAGS = -p ..:${APSTOP}/base -G
 
 SCALAGEN = simple.scala classic-binding.scala tiny.scala \
 	test-coll.scala test-use-coll.scala test-cycle.scala use-global.scala \
-	grammar.scala first.scala follow.scala
+	grammar.scala first.static.scala follow.static.scala nullable.static.scala
 
 MISCGEN = nested-cycles.scala GrammarParser.scala SimpleParser.scala \
 	GrammarTokens.scala SimpleTokens.scala *.scala~ GrammarScanner.scala \
@@ -36,7 +36,7 @@ run: Classic.run TestCollDriver.run TestCycleDriver.run NestedCyclesDriver.run
 phony_explicit:
 
 %.static.scala : ../%.aps ${APS2SCALA}
-	${APS2SCALA} ${APS2SCALAFLAGS} -S $*
+	${APS2SCALA} ${APS2SCALAFLAGS} -S -C $*
 
 %.scala : ../%.aps ${APS2SCALA}
 	${APS2SCALA} ${APS2SCALAFLAGS} $*

--- a/examples/scala/tests/Makefile
+++ b/examples/scala/tests/Makefile
@@ -17,7 +17,7 @@ clean:
 	scalac -cp ${SCALA_FLAGS} $<
 
 first.scala follow.scala nullable.scala:
-	${APS2SCALA} -S -C -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base $(basename $(@F))
+	${APS2SCALA} -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base -S $(basename $(@F))
 
 %.scala:
 	${APS2SCALA} -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base $*

--- a/examples/scala/tests/Makefile
+++ b/examples/scala/tests/Makefile
@@ -17,7 +17,7 @@ clean:
 	scalac -cp ${SCALA_FLAGS} $<
 
 first.scala follow.scala nullable.scala:
-	${APS2SCALA} -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base -S $(basename $(@F))
+	${APS2SCALA} -S -C -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base $(basename $(@F))
 
 %.scala:
 	${APS2SCALA} -DCOT -p ${EXAMPLES_PATH}:${ROOT_PATH}/base $*


### PR DESCRIPTION
Modified the `%.static.scala` target to build using `-C` flag (circular static schedule) for first, follow and nullable

Because first, follow and nullable don't work with the old static scheduler. They only work with demand scheduler OR circular static scheduler.