### PR TITLE
Disallow fixed point loops if state->loop_required is false

### DIFF
--- a/codegen/static-scc-impl.cc
+++ b/codegen/static-scc-impl.cc
@@ -771,6 +771,7 @@ static void dump_visit_functions(PHY_GRAPH* phy_graph,
   Declaration tlm = aug_graph->match_rule;
   Match m = top_level_match_m(tlm);
   Block block = matcher_body(m);
+  STATE* s = phy_graph->global_state;
 
 #ifndef APS2SCALA
   ostream& hs = oss.hs;
@@ -831,7 +832,7 @@ static void dump_visit_functions(PHY_GRAPH* phy_graph,
 
     OutputWriter ow(os);
     implement_visit_function(aug_graph, phase, total_order, instance_assignment,
-                             nch, &cond, -1, true, -1, true, &ow);
+                             nch, &cond, -1, s->loop_required, -1, true, &ow);
 
     --nesting_level;
 #ifdef APS2SCALA


### PR DESCRIPTION
`state->loop_required` is `true` only when the cycle is not just fiber and actually carries value. This code effectively disallows fixed-point loops in fiber cycles.

This code became necessary because we are not removing fiber cycles anymore in UP/DOWN so code generation thought there is a genuine cycle, but there is none. We already know the cycle does OR doesn't carry value using `state->loop_required`.