### PR TITLE
Fixed SIMPLE examples so they can be code generated

### DIFF
--- a/examples/simple-coag.aps
+++ b/examples/simple-coag.aps
@@ -43,4 +43,34 @@ module SIMPLE_OAG[T :: var SIMPLE[]] extends T begin
   match ?d:Decl=decl(?id:String,?ty:Type) begin
     d.bs := d.bi + 1;
   end;
+
+  match ?p:Program=program(?b:Block) begin
+  end;
+
+  match ?t:Type=integer_type() begin
+  end;
+  
+  match ?t:Type=string_type() begin
+  end;
+
+  match ?:Stmts=no_stmts() begin
+  end;
+  
+  match ?ss0:Stmts=xcons_stmts(?ss1:Stmts,?s:Stmt) begin
+  end;
+
+  match ?s:Stmt=block_stmt(?b:Block) begin
+  end;
+  
+  match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
+  end;
+
+  match ?e:Expr=intconstant(?:Integer) begin
+  end;
+  
+  match ?e:Expr=strconstant(?:String) begin
+  end;
+
+  match ?e:Expr=variable(?id:String) begin
+  end;
 end;

--- a/examples/simple-oag.aps
+++ b/examples/simple-oag.aps
@@ -12,7 +12,7 @@ module SIMPLE_OAG[T :: var SIMPLE[]] extends T begin
 
   pragma inherited(ai1,ai2,bi);
   pragma synthesized(as1,as2,bs,total);
-
+  
   match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
     ds.ai1 := 12;
     ds.ai2 := ds.as1;

--- a/examples/simple-oag.aps
+++ b/examples/simple-oag.aps
@@ -12,7 +12,7 @@ module SIMPLE_OAG[T :: var SIMPLE[]] extends T begin
 
   pragma inherited(ai1,ai2,bi);
   pragma synthesized(as1,as2,bs,total);
-  
+
   match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
     ds.ai1 := 12;
     ds.ai2 := ds.as1;
@@ -34,5 +34,35 @@ module SIMPLE_OAG[T :: var SIMPLE[]] extends T begin
   
   match ?d:Decl=decl(?id:String,?ty:Type) begin
     d.bs := d.bi + 1;
+  end;
+
+  match ?p:Program=program(?b:Block) begin
+  end;
+
+  match ?t:Type=integer_type() begin
+  end;
+  
+  match ?t:Type=string_type() begin
+  end;
+
+  match ?:Stmts=no_stmts() begin
+  end;
+  
+  match ?ss0:Stmts=xcons_stmts(?ss1:Stmts,?s:Stmt) begin
+  end;
+
+  match ?s:Stmt=block_stmt(?b:Block) begin
+  end;
+  
+  match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
+  end;
+
+  match ?e:Expr=intconstant(?:Integer) begin
+  end;
+  
+  match ?e:Expr=strconstant(?:String) begin
+  end;
+
+  match ?e:Expr=variable(?id:String) begin
   end;
 end;

--- a/examples/simple-snc.aps
+++ b/examples/simple-snc.aps
@@ -23,4 +23,40 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
     e.s1 := e.i1;
     e.s2 := e.i2;
   end;
+
+  match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
+  end;
+
+  match ?ds:Decls=no_decls() begin
+  end;
+  
+  match ?ds0:Decls=xcons_decls(?ds1:Decls,?d:Decl) begin
+  end;
+
+  match ?d:Decl=decl(?id:String,?ty:Type) begin
+  end;
+
+  match ?p:Program=program(?b:Block) begin
+  end;
+
+  match ?t:Type=integer_type() begin
+  end;
+  
+  match ?t:Type=string_type() begin
+  end;
+
+  match ?:Stmts=no_stmts() begin
+  end;
+  
+  match ?ss0:Stmts=xcons_stmts(?ss1:Stmts,?s:Stmt) begin
+  end;
+
+  match ?s:Stmt=block_stmt(?b:Block) begin
+  end;
+  
+  match ?e:Expr=strconstant(?:String) begin
+  end;
+
+  match ?e:Expr=variable(?id:String) begin
+  end;
 end;

--- a/examples/simple-syn.aps
+++ b/examples/simple-syn.aps
@@ -46,5 +46,4 @@ module SIMPLE_SYN[T :: var SIMPLE[]] extends T begin
 
   match ?e:Expr=variable(?id:String) begin
   end;
-
 end;

--- a/examples/simple-syn.aps
+++ b/examples/simple-syn.aps
@@ -10,5 +10,41 @@ module SIMPLE_SYN[T :: var SIMPLE[]] extends T begin
   match ?ds0:Decls=xcons_decls(?ds1:Decls,?d:Decl) begin
     ds0.decl_count := ds1.decl_count + 1;
   end;
+
+  match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
+  end;
+
+  match ?d:Decl=decl(?id:String,?ty:Type) begin
+  end;
+
+  match ?p:Program=program(?b:Block) begin
+  end;
+
+  match ?t:Type=integer_type() begin
+  end;
   
+  match ?t:Type=string_type() begin
+  end;
+
+  match ?:Stmts=no_stmts() begin
+  end;
+  
+  match ?ss0:Stmts=xcons_stmts(?ss1:Stmts,?s:Stmt) begin
+  end;
+
+  match ?s:Stmt=block_stmt(?b:Block) begin
+  end;
+  
+  match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
+  end;
+
+  match ?e:Expr=intconstant(?:Integer) begin
+  end;
+  
+  match ?e:Expr=strconstant(?:String) begin
+  end;
+
+  match ?e:Expr=variable(?id:String) begin
+  end;
+
 end;


### PR DESCRIPTION
APS does not complain about missing top-level-match during scheduling

But complains about them during code generation.

If the goal of these examples is just scheduling then we don't need this PR but if we want to test code generation then this PR is needed.