### PR TITLE
Better error description in aps-type

### DIFF
--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -276,6 +276,22 @@ static void* do_typechecking(void* ignore, void*node) {
 
 	  while (ABSTRACT_APS_tnode_phylum(tdecl) != KEYDeclaration)
 	    tdecl = (Declaration)tnode_parent(tdecl);
+
+          switch (Declaration_KEY(tdecl))
+          {
+          case KEYsome_value_decl:
+          {
+            char value_decl_type_str[BUFFER_SIZE];
+            FILE* f = fmemopen(value_decl_type_str, sizeof(value_decl_type_str), "w");
+            print_Type(some_value_decl_type(tdecl), f);
+            fclose(f);
+            aps_error(tdecl,"Expected type_decl but got value_decl %s", value_decl_type_str);
+            break;
+          }
+          default:
+            break;
+          }
+
 	  tu = use(def_name(some_type_decl_def(tdecl)));
 	  te->outer = USE_TYPE_ENV(mu);
 	  te->source = mdecl;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -286,7 +286,7 @@ static void* do_typechecking(void* ignore, void*node) {
             print_Type(some_value_decl_type(tdecl), f);
             fclose(f);
             aps_error(tdecl, "Expected use of a type declaration, not a type construction (%s).", value_decl_type_str);
-            break;
+            return 0;
           }
           default:
             break;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -285,7 +285,7 @@ static void* do_typechecking(void* ignore, void*node) {
             FILE* f = fmemopen(value_decl_type_str, sizeof(value_decl_type_str), "w");
             print_Type(some_value_decl_type(tdecl), f);
             fclose(f);
-            aps_error(tdecl,"Expected use of a type declaration, not a type construction (%s).", value_decl_type_str);
+            aps_error(tdecl, "Expected use of a type declaration, not a type construction (%s).", value_decl_type_str);
             break;
           }
           default:

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -285,7 +285,7 @@ static void* do_typechecking(void* ignore, void*node) {
             FILE* f = fmemopen(value_decl_type_str, sizeof(value_decl_type_str), "w");
             print_Type(some_value_decl_type(tdecl), f);
             fclose(f);
-            aps_error(tdecl,"Expected type_decl but got value_decl %s", value_decl_type_str);
+            aps_error(tdecl,"Expected use of a type declaration, not a type construction (%s).", value_decl_type_str);
             break;
           }
           default:


### PR DESCRIPTION
If a user uses a value decl instead of a type decl when defining attribute type:
```
 -- Instead of LIST[BindingPair] the user should used type declaration instead (i.e. Environment)
attribute Formals.formals_bindingpairs : LIST[BindingPair];
```

They will get an error:
```
fatal error: some_type_decl_def: called with value_decl
```

But now they will get a more descriptive error 
```
cool-noinherit-semant.aps:132:Expected use of a type declaration, not a type construction (LIST[BindingPair])
```