### PR TITLE
(Feature) Enable short-circuiting in Scala code generation

### DIFF
--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -1,7 +1,11 @@
 import Evaluation._;
 
 object basic_implicit {
-  private def eager[T](f: (=>T, =>T) => T): (T, T) => T = (a: T, b: T) => f(a, b);
+  private object Conversions {
+    implicit def lazyToEager[T](f: (=>T, =>T) => T): (T, T) => T = (a: T, b: T) => f(a, b)
+  }
+
+  import Conversions._
 
   val t_Boolean = new M_BOOLEAN("Boolean");
   type T_Boolean = Boolean;
@@ -53,7 +57,7 @@ object basic_implicit {
 
   type T_MAKE_LATTICE[L] = L;
 
-  val t_OrLattice = new M_MAKE_LATTICE[T_Boolean]("OrLattice",t_Boolean,v_false,v_cand,v_implies,eager(v_or),eager(v_and))
+  val t_OrLattice = new M_MAKE_LATTICE[T_Boolean]("OrLattice",t_Boolean,v_false,v_cand,v_implies,v_or,v_and)
     with C_TYPE[Boolean]
     with C_COMBINABLE[Boolean]
     with C_LATTICE[Boolean] {
@@ -63,7 +67,7 @@ object basic_implicit {
   }
   type T_OrLattice = T_Boolean;
 
-  val t_AndLattice = new M_MAKE_LATTICE[T_Boolean]("AndLattice",t_Boolean,v_true,v_andc,v_revimplies,eager(v_and),eager(v_or))
+  val t_AndLattice = new M_MAKE_LATTICE[T_Boolean]("AndLattice",t_Boolean,v_true,v_andc,v_revimplies,v_and,v_or)
     with C_TYPE[Boolean]
     with C_COMBINABLE[Boolean]
     with C_LATTICE[Boolean] {

--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -1,14 +1,16 @@
 import Evaluation._;
 
 object basic_implicit {
+  private def eager[T](f: (=>T, =>T) => T): (T, T) => T = (a: T, b: T) => f(a, b);
+
   val t_Boolean = new M_BOOLEAN("Boolean");
   type T_Boolean = Boolean;
   val v_true:T_Boolean = true;
   val v_false:T_Boolean = false;
   val v_and = f_and _;
-  def f_and(v__23 : T_Boolean, v__24 : T_Boolean):T_Boolean = v__23 && v__24;
+  def f_and(v__23: => T_Boolean, v__24: => T_Boolean): T_Boolean = v__23 && v__24;
   val v_or = f_or _;
-  def f_or(v__25 : T_Boolean, v__26 : T_Boolean):T_Boolean = v__25 || v__26;
+  def f_or(v__25: => T_Boolean, v__26: => T_Boolean): T_Boolean = v__25 || v__26;
   val v_not = f_not _;
   def f_not(v__27 : T_Boolean):T_Boolean = !v__27;
 
@@ -51,7 +53,7 @@ object basic_implicit {
 
   type T_MAKE_LATTICE[L] = L;
 
-  val t_OrLattice = new M_MAKE_LATTICE[T_Boolean]("OrLattice",t_Boolean,v_false,v_cand,v_implies,v_or,v_and)
+  val t_OrLattice = new M_MAKE_LATTICE[T_Boolean]("OrLattice",t_Boolean,v_false,v_cand,v_implies,eager(v_or),eager(v_and))
     with C_TYPE[Boolean]
     with C_COMBINABLE[Boolean]
     with C_LATTICE[Boolean] {
@@ -61,7 +63,7 @@ object basic_implicit {
   }
   type T_OrLattice = T_Boolean;
 
-  val t_AndLattice = new M_MAKE_LATTICE[T_Boolean]("AndLattice",t_Boolean,v_true,v_andc,v_revimplies,v_and,v_or)
+  val t_AndLattice = new M_MAKE_LATTICE[T_Boolean]("AndLattice",t_Boolean,v_true,v_andc,v_revimplies,eager(v_and),eager(v_or))
     with C_TYPE[Boolean]
     with C_COMBINABLE[Boolean]
     with C_LATTICE[Boolean] {

--- a/base/scala/basic.handcode.scala
+++ b/base/scala/basic.handcode.scala
@@ -12,9 +12,9 @@ object basic_implicit {
   val v_true:T_Boolean = true;
   val v_false:T_Boolean = false;
   val v_and = f_and _;
-  def f_and(v__23: => T_Boolean, v__24: => T_Boolean): T_Boolean = v__23 && v__24;
+  def f_and(v__23: => T_Boolean, v__24: => T_Boolean):T_Boolean = v__23 && v__24;
   val v_or = f_or _;
-  def f_or(v__25: => T_Boolean, v__26: => T_Boolean): T_Boolean = v__25 || v__26;
+  def f_or(v__25: => T_Boolean, v__26: => T_Boolean):T_Boolean = v__25 || v__26;
   val v_not = f_not _;
   def f_not(v__27 : T_Boolean):T_Boolean = !v__27;
 


### PR DESCRIPTION
The idea is instead of `T` we use `=>T` which lazily evaluates the value, hence short-circuiting.

This is all the code change needed to enable this feature. The generated code still type checks.

**Note**: the implicit cast from lazy to eager is needed because the `and` and `or` functions are used in `OrLattice` and `AndLattice` and the lazy versions don't type check so we need an implicit cast to convert lazy back to eager.