### PR TITLE
Update Grammar.y to be left recursive and use less runtime stack

### DIFF
--- a/examples/scala/Grammar.y
+++ b/examples/scala/Grammar.y
@@ -12,7 +12,7 @@
 %type <Items> items
 %type <Item> item
 %type <ItemsMany> items_many
-%type <Productions> productions production_alt
+%type <Productions> productions production
 %%
 
 grammar : productions
@@ -21,11 +21,11 @@ grammar : productions
 
 productions : /* NOTHING */
    { $$ = productions_none(); }
-      | production_alt SEMICOLON productions
-   { $$ = productions_append($1, $3); }
+      | productions production
+   { $$ = productions_append($1, $2); }
       ;
 
-production_alt : NONTERMINAL COLON items_many
+production : NONTERMINAL COLON items_many SEMICOLON
    { $$ = prods($1, $3); }
       ;
 
@@ -37,8 +37,8 @@ items_many : items
 
 items :  /* NOTHING */
    { $$ = items_none(); }
-      | item items
-   { $$ = items_append(items_single($1), $2); }
+      | items item
+   { $$ = items_append($1, items_single($2)); }
       ;
 
 item : TERMINAL


### PR DESCRIPTION
Tested this against Antlr for a randomly generated CFG (20+ MB file)

Scala-Bison: 4.2 seconds, ~500MB memory
Antlr in Java: 3.3 seconds, ~400MB memory

These numbers are on average of 3 runs.