### PR TITLE
for-in-stmt code generation in Scala only

### DIFF
--- a/aps2scala/dump-scala.cc
+++ b/aps2scala/dump-scala.cc
@@ -801,6 +801,8 @@ void dump_local_attributes(Block b, Type at, Implementation::ModuleInfo* info,
     default:
       aps_error(d,"Cannot handle this kind of statement");
       break;
+    case KEYfor_in_stmt:
+      break;
     case KEYvalue_decl:
       {
         static int unique = 0;

--- a/codegen/static-scc-impl.cc
+++ b/codegen/static-scc-impl.cc
@@ -427,9 +427,13 @@ static bool implement_visit_function(
     }
 
     Declaration ad = in->fibered_attr.attr;
+    void* ad_parent = ad != NULL ? tnode_parent(ad) : NULL;
 
     bool node_is_lhs = in->node == aug_graph->lhs_decl;
     bool node_is_syntax = ch < nch || node_is_lhs;
+    bool node_is_for_in_stmt = ad_parent != NULL &&
+                               ABSTRACT_APS_tnode_phylum(ad_parent) == KEYDeclaration &&
+                               Declaration_KEY((Declaration)ad_parent) == KEYfor_in_stmt;
 
     CONDITION icond = instance_condition(in);
     if (MERGED_CONDITION_IS_IMPOSSIBLE(*cond, icond)) {
@@ -441,6 +445,49 @@ static bool implement_visit_function(
             << icond.positive << ",-" << icond.negative << ")\n";
       }
       continue;
+    }
+
+    if (node_is_for_in_stmt) {
+      Declaration for_in_stmt_decl = (Declaration)ad_parent;
+      Block body = for_in_stmt_body(for_in_stmt_decl);
+      Declaration formal = for_in_stmt_formal(for_in_stmt_decl);
+      Expression sequence = for_in_stmt_seq(for_in_stmt_decl);
+
+      bool prev_loop_allowed = loop_allowed;
+      if (loop_allowed) {
+        // If loop is allowed, and we are not in the loop already then allow
+        // loops inside the for-in-stmt.
+        loop_allowed = loop_id == -1;
+      }
+
+#ifdef APS2SCALA
+        ow->get_outstream() << indent() << "for (v_" << decl_name(formal) << " <- " << sequence << ") {\n";
+        ++nesting_level;
+#endif /* APS2SCALA */
+
+      vector<std::set<Expression> > assignment =
+          make_instance_assignment(aug_graph, body, instance_assignment);
+
+      bool cont = implement_visit_function(aug_graph, phase, cto->cto_next,
+                               assignment, nch, cond, cto->chunk_index,
+                               loop_allowed, loop_id, skip_previous_visit_code,
+                               ow);
+
+#ifdef APS2SCALA
+      --nesting_level;
+      ow->get_outstream() << indent() << "}\n";
+
+
+      // Restore previous value of loop allowed.
+      loop_allowed = prev_loop_allowed;
+
+      // Closing of the loop now that for-in-stmt is finished
+      if (loop_allowed && loop_id != -1) {
+        dump_loop_end(aug_graph, phase, loop_id, ow);
+        loop_id = -1;
+      }
+#endif /* APS2SCALA */
+      return cont;
     }
 
     if (if_rule_p(ad)) {


### PR DESCRIPTION
No compile error or warning. Tested with `test-forin.aps`

Static code gen:

```scala
  def visit_0_1(node : T_Root) : Unit = node match {
    case p_root(_,_) => visit_0_1_0(node);
  };
  def visit_0_2(node : T_Root) : Unit = node match {
    case p_root(_,_) => visit_0_2_0(node);
  };
  def visit_0_1_0(anchor : T_Root) : Unit = anchor match {
    case p_root(v_r,v_w) => {

      visit_1_1(v_w);
    }
  }
  def visit_0_2_0(anchor : T_Root) : Unit = anchor match {
    case p_root(v_r,v_w) => {
      for (v_leaf <- v_all_leaves) {
        a_answer.set(v_r,v_leaf);
      }
    }
  }
```

Dynamic code gen:

```scala
  def c_answer(anode : T_Root) : T_Biggest = {
    var collection : T_Biggest = t_Biggest.v_initial;
    for (anchor <- t_Result.t_Root.nodes) anchor match {
      case p_root(v_r,v_w) => {
        for (v_leaf <- v_all_leaves) {
          if (anode eq v_r) collection = t_Biggest.v_combine(collection,v_leaf);
        }
      }
      case _ => {}
    }
    return collection;
  }
```