### PR TITLE
Marking objects (value_decls that have phylum type)

### DIFF
--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -1770,6 +1770,16 @@ static void *mark_local(void *ignore, void *node) {
   return node;
 }
 
+static void *mark_obj(void *ignore, void *node) {
+  if (ABSTRACT_APS_tnode_phylum(node) == KEYDeclaration) {
+    Declaration decl = (Declaration)node;
+    if (Declaration_KEY(decl) == KEYvalue_decl && type_is_phylum(value_decl_type(decl))) {
+      Declaration_info(decl)->decl_flags |= DECL_OBJECT_FLAG;
+    }
+  }
+  return node;
+}
+
 static void init_node_phy_graph2(Declaration node, Type ty, STATE *state) { 
   switch (Type_KEY(ty)) {
   default:
@@ -2194,6 +2204,9 @@ static void init_analysis_state(STATE *s, Declaration module) {
 
   /* mark all local declarations such */
   traverse_Declaration(mark_local,module,module);
+
+  /* mark obj decls */
+  traverse_Declaration(mark_obj,module,module);
 
   /* get phyla (imported only) */
   { Declaration tf=first_Declaration(type_formals);

--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -1770,7 +1770,7 @@ static void *mark_local(void *ignore, void *node) {
   return node;
 }
 
-static void *mark_obj(void *ignore, void *node) {
+static void *mark_object_flag(void *ignore, void *node) {
   if (ABSTRACT_APS_tnode_phylum(node) == KEYDeclaration) {
     Declaration decl = (Declaration)node;
     if (Declaration_KEY(decl) == KEYvalue_decl && type_is_phylum(value_decl_type(decl))) {
@@ -2206,7 +2206,7 @@ static void init_analysis_state(STATE *s, Declaration module) {
   traverse_Declaration(mark_local,module,module);
 
   /* mark obj decls */
-  traverse_Declaration(mark_obj,module,module);
+  traverse_Declaration(mark_object_flag,module,module);
 
   /* get phyla (imported only) */
   { Declaration tf=first_Declaration(type_formals);


### PR DESCRIPTION
Marking objects (i.e. value_decls that have phylum type) with `DECL_OBJECT_FLAG`. This change doesn't cause any problems.