### PR TITLE
fix small merge error that caused compile error

### DIFF
--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -5,6 +5,7 @@
 #include "aps-ag.h"
 
 int type_debug = FALSE;
+static int BUFFER_SIZE = 1000;
 
 static Type Boolean_Type;
 static Type Integer_Type;


### PR DESCRIPTION
`BUFFER_SIZE` was used in `aps-type.c` but its declaration was missing