### PR TITLE
function call proxy can be involved in a cycle

### DIFF
--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -875,6 +875,17 @@ static void assert_circular_declaration(STATE* s) {
             if (declared_circular) {
               any_cycle = true;
             } else {
+              if (instance->node != NULL && 
+                  ABSTRACT_APS_tnode_phylum(instance->node) == KEYDeclaration &&
+                  Declaration_KEY(instance->node) == KEYpragma_call) {
+
+                if (cycle_debug & DEBUG_UP_DOWN) {
+                  printf("function call proxy (%s) involves in a cycle\n", instance_to_str);
+                }
+
+                continue;
+              }
+
               aps_error(node,
                         "Instance (%s) involves in a cycle but it is not "
                         "declared circular.",


### PR DESCRIPTION
function call proxy can be involved in a cycle, its not a error

```
function call proxy (make_type(...):359.G[make_type]'shared_info) involves in a cycle
```