### PR TITLE
function decl VAR detection during type-checking + fixes

### DIFF
--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -636,7 +636,7 @@ static bool sig_is_var(Signature sig) {
   }
 }
 
-static void ensure_non_var_use(Declaration fdecl, void * source, void * current) {
+static void ensure_non_var_use(Declaration fdecl, void* source, void* current) {
   switch (ABSTRACT_APS_tnode_phylum(current)) {
   case KEYExpression: {
     Expression expr = (Expression) current;

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -615,7 +615,7 @@ Type infer_expr_type(Expression e)
   return ty;
 }
 
-static Declaration is_inside_function(void *node) {
+static Declaration is_inside_function(void* node) {
   while (node != NULL) {
     if (ABSTRACT_APS_tnode_phylum((Declaration)node) == KEYDeclaration &&
         Declaration_KEY((Declaration)node) == KEYfunction_decl) {

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -682,19 +682,22 @@ static void ensure_non_var_use(Declaration fdecl, void * source, void * current)
     switch (Declaration_KEY(decl)) {
     case KEYvalue_decl: {
       if (is_inside_function(decl) != fdecl && !def_is_constant(value_decl_def(decl))) {
-        aps_error(source, "non-constant value '%s' used inside constant function '%s' but declared outside of function", decl_name(decl), decl_name(fdecl));
+        aps_error(source, "non-constant value '%s' used inside constant function '%s' but declared outside of function",
+          decl_name(decl), decl_name(fdecl));
       }
       break;
     }
     case KEYattribute_decl: {
       if (!def_is_constant(attribute_decl_def(decl))) {
-        aps_error(source, "attribute '%s' used inside constant function '%s'", decl_name(decl), decl_name(fdecl));
+        aps_error(source, "attribute '%s' used inside constant function '%s'",
+          decl_name(decl), decl_name(fdecl));
       }
       break;
     }
     case KEYfunction_decl: {
       if (!def_is_constant(function_decl_def(decl))) {
-        aps_error(source, "function call to non-constant function '%s' inside constant function '%s'", decl_name(decl), decl_name(fdecl));
+        aps_error(source, "function call to non-constant function '%s' inside constant function '%s'",
+          decl_name(decl), decl_name(fdecl));
       }
       break;
     }

--- a/analyze/aps-type.c
+++ b/analyze/aps-type.c
@@ -615,6 +615,99 @@ Type infer_expr_type(Expression e)
   return ty;
 }
 
+static Declaration is_inside_function(void *node) {
+  while (node != NULL) {
+    if (ABSTRACT_APS_tnode_phylum((Declaration)node) == KEYDeclaration &&
+        Declaration_KEY((Declaration)node) == KEYfunction_decl) {
+      return (Declaration)node;
+    }
+
+    node = tnode_parent(node);
+  }
+  return NULL;
+}
+
+static bool sig_is_var(Signature sig) {
+  switch (Signature_KEY(sig)) {
+  case KEYsig_inst:
+    return sig_inst_is_var(sig);
+  default:
+    return false;
+  }
+}
+
+static void ensure_non_var_use(Declaration fdecl, void * source, void * current) {
+  switch (ABSTRACT_APS_tnode_phylum(current)) {
+  case KEYExpression: {
+    Expression expr = (Expression) current;
+    switch (Expression_KEY(expr)) {
+    case KEYfuncall: {
+      ensure_non_var_use(fdecl, source, funcall_f(expr));
+      break;
+    }
+    case KEYvalue_use: {
+      Use use = value_use_use(expr);
+      Declaration udecl = USE_DECL(use);
+
+      switch (Use_KEY(use)) {
+      case KEYqual_use: {
+        // Convert type-use to Declaration
+        Declaration decl = canonical_type_decl(canonical_type(qual_use_from(use)));
+        switch (Declaration_KEY(decl)) {
+        case KEYsome_type_formal:
+          // Special case when type formal is VAR, its functions are considered constant
+          if (sig_is_var(some_type_formal_sig(decl))) {
+            return;
+          }
+          break;
+        default:
+          break;
+        }
+        break;
+      }
+      default:
+        break;
+      }
+
+      ensure_non_var_use(fdecl, source, udecl); // investigate the use
+      break;
+    }
+    default:
+      break;
+    }
+    break;
+  }
+  case KEYDeclaration: {
+    Declaration decl = (Declaration) current;
+    switch (Declaration_KEY(decl)) {
+    case KEYvalue_decl: {
+      if (is_inside_function(decl) != fdecl && !def_is_constant(value_decl_def(decl))) {
+        aps_error(source, "non-constant value '%s' used inside constant function '%s' but declared outside of function", decl_name(decl), decl_name(fdecl));
+      }
+      break;
+    }
+    case KEYattribute_decl: {
+      if (!def_is_constant(attribute_decl_def(decl))) {
+        aps_error(source, "attribute '%s' used inside constant function '%s'", decl_name(decl), decl_name(fdecl));
+      }
+      break;
+    }
+    case KEYfunction_decl: {
+      if (!def_is_constant(function_decl_def(decl))) {
+        aps_error(source, "function call to non-constant function '%s' inside constant function '%s'", decl_name(decl), decl_name(fdecl));
+      }
+      break;
+    }
+    default:
+      break;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+}
+
 void check_expr_type(Expression e, Type type)
 {
   if (type == 0) {
@@ -625,6 +718,12 @@ void check_expr_type(Expression e, Type type)
     check_type_equal(e,type,Expression_info(e)->expr_type);
     return;
   }
+
+  Declaration fdecl;
+  if ((fdecl = is_inside_function(e)) != NULL && def_is_constant(function_decl_def(fdecl))) {
+    ensure_non_var_use(fdecl, e, e);
+  }
+
   switch (Expression_KEY(e)) {
   case KEYvalue_use:
     {

--- a/examples/below-fiber-cycle.aps
+++ b/examples/below-fiber-cycle.aps
@@ -39,7 +39,7 @@ module BELOW_FIBER_CYCLE[T :: var TINY[]] extends T begin
     this.syn := scope_depth(index_scope(this.scope,n));
   end;
 
-  function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
+  var function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
     if sc = nil or i = 0 then
       result := sc;
     else

--- a/examples/below-single-fiber-cycle.aps
+++ b/examples/below-single-fiber-cycle.aps
@@ -36,7 +36,7 @@ module BELOW_SINGLE_FIBER_CYCLE[T :: var TINY[]] extends T begin
     this.syn := scope_depth(index_scope(this.scope,n));
   end;
 
-  function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
+  var function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
     if sc = nil or i = 0 then
       result := sc;
     else

--- a/examples/bigger-binding.aps
+++ b/examples/bigger-binding.aps
@@ -62,7 +62,7 @@ module CODE_GENERATION[T :: var BIGGER[]] extends T begin
   attribute Type.type_shape : Shape;
   attribute Expr.expr_shape : Shape;
 
-  collection size : Integer :> 0, (+);
+  var collection size : Integer :> 0, (+);
 
   pragma inherited(block_scope,decls_scope,decl_scope,
 		   stmts_scope,stmt_scope,expr_scope);

--- a/examples/broad-fiber-cycle.aps
+++ b/examples/broad-fiber-cycle.aps
@@ -46,7 +46,7 @@ module BROAD_FIBER_CYCLE[T :: var TINY[]] extends T begin
     this.syn := scope_depth(index_scope(this.scope2,n));
   end;
 
-  function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
+  var function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
     if sc = nil or i = 0 then
       result := sc;
     else

--- a/examples/local-fiber-cycle.aps
+++ b/examples/local-fiber-cycle.aps
@@ -39,7 +39,7 @@ module LOCAL_FIBER_CYCLE[T :: var TINY[]] extends T begin
     this.syn := scope_depth(index_scope(this.scope,n));
   end;
 
-  function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
+  var function index_scope(sc : ContextPtr; i : Integer) : ContextPtr begin
     if sc = nil or i = 0 then
       result := sc;
     else

--- a/examples/remote-binding.aps
+++ b/examples/remote-binding.aps
@@ -18,7 +18,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
 
   pragma synthesized(decl_used);
 
-  function entity_shape(e : EntityRef) : Shape begin
+  var function entity_shape(e : EntityRef) : Shape begin
     case e begin
       match decl(?, ?ty) begin
 	result := ty.type_shape;
@@ -133,7 +133,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
     endif;
   end;
   
-  function lookup(name : String; scope : Scope) : EntityRef begin
+  var function lookup(name : String; scope : Scope) : EntityRef begin
     if scope = root_scope then
       result := not_found;
     else

--- a/examples/simple-binding.aps
+++ b/examples/simple-binding.aps
@@ -148,7 +148,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
     endif;
   end;
   
-  function lookup(name : String; scope : Scope) : EntityRef begin
+  var function lookup(name : String; scope : Scope) : EntityRef begin
     if scope = root_scope then
       result := not_found;
     else

--- a/examples/simple-binding1.aps
+++ b/examples/simple-binding1.aps
@@ -140,7 +140,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
     endif;
   end;
   
-  function lookup(name : String; scope : Scope) : EntityRef begin
+  var function lookup(name : String; scope : Scope) : EntityRef begin
     if scope = root_scope then
       result := not_found;
     else

--- a/examples/simple-binding3.aps
+++ b/examples/simple-binding3.aps
@@ -171,7 +171,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
     end;
   end;
 
-  function lookup(name : String; scope : Scope) : EntityRef begin
+  var function lookup(name : String; scope : Scope) : EntityRef begin
     if scope = root_scope then
       result := not_found;
     else

--- a/examples/type-binding.aps
+++ b/examples/type-binding.aps
@@ -184,7 +184,7 @@ module TYPE_BINDING[T :: var TYPE_DECL[]] extends T begin
     e.expr_shape := element_type(a.expr_shape);
   end;
   
-  function element_type(at : Shape) : Shape begin
+  var function element_type(at : Shape) : Shape begin
     case at begin
       match vector_shape(?et:Shape) begin
 	result := et;


### PR DESCRIPTION
a case-by-case analysis of when function declaration needs VAR

COOL semant repos need to be fixed as well: https://github.com/boyland/aps-cool/pull/4