### PR TITLE
function formals should not be involved in a cycle

### DIFF
--- a/analyze/aps-cycle.c
+++ b/analyze/aps-cycle.c
@@ -780,7 +780,17 @@ static bool applicable_for_circularity_check(INSTANCE *instance)
     switch (Declaration_KEY(node))
     {
     case KEYformal:
-      return false;
+    {
+      switch (ABSTRACT_APS_tnode_phylum(tnode_parent(node)))
+      {
+      case KEYPattern:
+        // formals used inside match patterns are allowed to be
+        // involved in a cycle.
+        return false;
+      default:
+        break;
+      }
+    }
     default:
       break;
     }

--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -2439,6 +2439,8 @@ static void synchronize_dependency_graphs(AUG_GRAPH *aug_graph,
     return;
   }
 
+  bool phylum_is_func_decl = Declaration_KEY(phy_graph->phylum) == KEYfunction_decl;
+
   phy_n = phy_graph->instances.length;
 
   /* discover when the instances for this node end.
@@ -2463,8 +2465,9 @@ static void synchronize_dependency_graphs(AUG_GRAPH *aug_graph,
       int aug_index = i*n + j;
       int sum_index = (i-start)*phy_n + (j-start);
       DEPENDENCY kind=edgeset_kind(aug_graph->graph[aug_index]);
+      // avoid adding augmeneted dependency graph edges to summary graph of function declarations
       if (!AT_MOST(dependency_indirect(kind),
-		   phy_graph->mingraph[sum_index])) {
+		   phy_graph->mingraph[sum_index]) && !phylum_is_func_decl) {
 	kind = dependency_indirect(kind); //! more precisely DNC artificial
 	kind = dependency_join(kind,phy_graph->mingraph[sum_index]);
 	if (kind == phy_graph->mingraph[sum_index]) {


### PR DESCRIPTION
Proxy parameters can be involved in cycles (not an error – even though function formals/result are not declared circular) but cycles don’t end up in the function which is scheduled by itself without caring about proxies.
