### PR TITLE
Possible solution to multiple assignment in SCC codegen

### DIFF
--- a/codegen/static-scc-impl.cc
+++ b/codegen/static-scc-impl.cc
@@ -127,7 +127,10 @@ static vector<std::set<Expression> > make_instance_assignment(
       // get default!
       switch (Declaration_KEY(ad)) {
         case KEYattribute_decl:
-          array[i].insert(default_init(attribute_decl_default(ad)));
+          // Multiple assignments to only collection attributes are permissible
+          if (array[i].empty() || (array[i].size() > 0 && direction_is_collection(attribute_decl_direction(ad)))) {
+            array[i].insert(default_init(attribute_decl_default(ad)));
+          }
           break;
         case KEYvalue_decl:
           array[i].insert(default_init(value_decl_default(ad)));


### PR DESCRIPTION
Possible solution to https://github.com/boyland/aps/issues/130

Given:

```ada
  attribute Root.root_list : VariableEnv := { 12  };

  match ?p=root(?w) begin
    p.root_list := {   };
  end;
```

Resulting generated code:

```scala
  def visit_0_1_0(anchor : T_Root) : Unit = anchor match {
    case p_root(v_p,v_w) => {

      visit_1_1(v_w);
      if (new M__basic_3[ T_Integer](t_Integer).v__op_1(a_total.get(v_w),0)) {
        a_result.set(v_p,a_total.get(v_w));
        a_root_list.set(v_p,t_VariableEnv.v_none());
      } else {
        a_result.set(v_p,100);
        a_root_list.set(v_p,t_VariableEnv.v_none());
      }
    }
  }
```

And given:

```ada
  attribute Root.root_list : VariableEnv := { 12  };

  match ?p=root(?w) begin
  end;
```

Resulting generated code:

```scala
  def visit_0_1_0(anchor : T_Root) : Unit = anchor match {
    case p_root(v_p,v_w) => {

      visit_1_1(v_w);
      if (new M__basic_3[ T_Integer](t_Integer).v__op_1(a_total.get(v_w),0)) {
        a_result.set(v_p,a_total.get(v_w));
        a_root_list.set(v_p,t_VariableEnv.v_single(12));
      } else {
        a_result.set(v_p,100);
        a_root_list.set(v_p,t_VariableEnv.v_single(12));
      }
    }
  }
```