### PR TITLE
Update simple-binding2.aps to add default for expr_shape

### DIFF
--- a/examples/simple-binding2.aps
+++ b/examples/simple-binding2.aps
@@ -48,6 +48,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
   
   not_found : EntityRef := nil;
   
+  no_shape : Shape := nil;
   int_shape : Shape := shape("integer");
   str_shape : Shape := shape("string");
 
@@ -63,7 +64,7 @@ module NAME_RESOLUTION[T :: var SIMPLE[]] extends T begin
   attribute Expr.expr_scope : Scope;
 
   attribute Type.type_shape : Shape;
-  attribute Expr.expr_shape : Shape;
+  attribute Expr.expr_shape : Shape := no_shape;
   
   pragma inherited(block_scope,decls_scope,decl_scope,
 		   stmts_scope,stmt_scope,expr_scope);


### PR DESCRIPTION
expr_shape is assigned in ELSE block of variable top-level-match, so it needs a default. Ideally, it should have been caught before