### PR TITLE
Fix issue with dynamic codegen of first.aps

### DIFF
--- a/examples/first.aps
+++ b/examples/first.aps
@@ -30,6 +30,8 @@ module FIRST[T :: var GRAMMAR[]] extends T begin
       match DeclarationTable$table_entry(?,?item_first_objs) begin
         self.item_first :> item_first_objs;
       end;
+      else
+        self.item_first := { };
     end;
   end;
 


### PR DESCRIPTION
Given this APS code of `first.aps`:

```c
  match ?self:Item=nonterminal(?s:Symbol) begin
    case DeclarationTable$select(firstTable, s) begin
      match DeclarationTable$table_entry(?,?item_first_objs) begin
        self.item_first :> item_first_objs;
      end;
    end;
  end;
```

In static code generation we get the following and it runs correctly. All good.

```scala
  def visit_1_2_1(anchor : T_Item, changed : AtomicBoolean) : Unit = anchor match {
    case p_nonterminal(v_self,v_s) => {
      val node = t_DeclarationTable.v_select(v_firstTable,v_s);
      node match {
        case t_DeclarationTable.p_table_entry(_,v_0,v_item_first_objs) => {
          a_item_first.set(v_self,v_item_first_objs, changed);
        }
        case _ => {
          a_item_first.set(v_self,t_SymbolLattice.v_none(), changed);
        }}
    }
  }
```

But in dynamic code generation we get the following which results in runtime match error crash

```scala
  def c_item_first(anode : T_Item) : T_SymbolLattice = {
    var collection : T_SymbolLattice = t_SymbolLattice.v_none();
    for (anchor <- t_Result.t_Item.nodes) anchor match {
      case p_terminal(v_self,v_s) => {
        if (anode eq v_self) collection = t_SymbolLattice.v_combine(collection,t_SymbolLattice.v_single(v_s));
      }
      case _ => {}
    }
    for (anchor <- t_Result.t_Item.nodes) anchor match {
      case p_nonterminal(v_self,v_s) => {
        t_DeclarationTable.v_select(v_firstTable,v_s) match {
          case t_DeclarationTable.p_table_entry(_,v_0,v_item_first_objs) => {
            if (anode eq v_self) collection = t_SymbolLattice.v_combine(collection,v_item_first_objs);
          }
        }
      }
      case _ => {}
    }
    return collection;
  }
```

```scala
Caused by: scala.MatchError: TreeMap() (of class scala.collection.immutable.TreeMap)
	at M_FIRST.$anonfun$c_item_first$2(first.scala:178)
	at M_FIRST.$anonfun$c_item_first$2$adapted(first.scala:176)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at M_FIRST.c_item_first(first.scala:176)
	at M_FIRST$E_item_first.compute(first.scala:104)
	at M_FIRST$E_item_first.compute(first.scala:99)
```

The root of the problem is this PR https://github.com/boyland/aps/pull/147

But after this APS fix, this will be the dynamic codegen output (notice else case was added):

```scala
  def c_item_first(anode : T_Item) : T_SymbolLattice = {
    var collection : T_SymbolLattice = t_SymbolLattice.v_none();
    for (anchor <- t_Result.t_Item.nodes) anchor match {
      case p_terminal(v_self,v_s) => {
        if (anode eq v_self) collection = t_SymbolLattice.v_combine(collection,t_SymbolLattice.v_single(v_s));
      }
      case _ => {}
    }
    for (anchor <- t_Result.t_Item.nodes) anchor match {
      case p_nonterminal(v_self,v_s) => {
        t_DeclarationTable.v_select(v_firstTable,v_s) match {
          case t_DeclarationTable.p_table_entry(_,v_0,v_item_first_objs) => {
            if (anode eq v_self) collection = t_SymbolLattice.v_combine(collection,v_item_first_objs);
          }
          case _ => {
            if (anode eq v_self) collection = t_SymbolLattice.v_combine(collection,t_SymbolLattice.v_none());
          }
        }
      }
      case _ => {}
    }
    return collection;
  }
```

Static code generated output is the same, no change.

Not sure if the right approach is fixing the `first.aps` or fixing the dynamic codegen to also dump default assignment.