### PR TITLE
Fix logic issue in aps-impl.scala that causes Farrow-UBD.aps (dynamic) to not evaluate correctly

### DIFF
--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -244,6 +244,8 @@ class Evaluation[T_P, T_V](val anchor : T_P, val name : String)
 	pending.pop();
 	if (inCycle != null) {
 	  evaluateCycle;
+	} else if (pending.exists(_.inCycle != null)) {
+	  status = UNEVALUATED
 	} else {
 	  status = EVALUATED;
 	}


### PR DESCRIPTION
`farrow-ubd.aps` in Static (-C) and Synth (-F) implementation is returning correct results given the following sample program. However, dynamic code gen doesn't return correct results. The problem is we have a non-circular `term-errs`  that depends on circular `term-val` and when `term-errs` is demanded, the chain of evaluation uses the current (incomplete) value of `term-val` and freezes the value as EVALUATED forever.

```
// Validating Farrow's use-before-declaration
a = b + c;
b = 42;
d = e + 1;
e = d - 1;
c = b * 2;
f = g + h;
h = a / 2;
```