### PR TITLE
Fix bug with collection assignments in static codegen

### DIFF
--- a/codegen/static-scc-impl.cc
+++ b/codegen/static-scc-impl.cc
@@ -162,9 +162,9 @@ static vector<std::set<Expression> > make_instance_assignment(
             if (in->index >= n)
               fatal_error("bad index [collection_assign] for instance");
 
-            if (step == 1)
+            if (step == 1 && include_initial_defaults)
               array[in->index].clear();
-            else
+            else if (step == 2)
               array[in->index].insert(assign_rhs(d));
           }
           break;


### PR DESCRIPTION
We shouldn't throw away collection assignments that happened in outer lexical scope because collections can be appended more than once.

See this `examples/nested-cycles.aps`

```sql
  match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
    circular collection out : NamesLattice;
    out :> s.stmt_assigned_in;
    -- monotone use of s.stmt_assigned_in in this condition:
    if e2.names_used <= s.stmt_assigned_in then
      out :> e1.names_used;
    endif;
    s.stmt_assigned_out := out;
  end;
```

Previously

```scala
  def visit_6_2_1(anchor : T_Stmt, changed : AtomicBoolean) : Unit = anchor match {
    case p_assign_stmt(v_s,v_e1,v_e2) => {
      if (new M__basic_3[ T_Names](t_Names).v__op_z0(a_names_used.get(v_e2),a_stmt_assigned_in.get(v_s))) {
        a1_out.set(anchor,a_names_used.get(v_e1), changed);
        a_stmt_assigned_out.set(v_s,a1_out.get(anchor), changed);
      } else {
        a1_out.set(anchor,a_stmt_assigned_in.get(v_s), changed);
        a_stmt_assigned_out.set(v_s,a1_out.get(anchor), changed);
      }
    }
  }
```

After the fix
```scala
  def visit_6_2_1(anchor : T_Stmt, changed : AtomicBoolean) : Unit = anchor match {
    case p_assign_stmt(v_s,v_e1,v_e2) => {
      if (new M__basic_3[ T_Names](t_Names).v__op_z0(a_names_used.get(v_e2),a_stmt_assigned_in.get(v_s))) {
        a1_out.set(anchor,a_stmt_assigned_in.get(v_s), changed); // <-- this was missing
        a1_out.set(anchor,a_names_used.get(v_e1), changed);
        a_stmt_assigned_out.set(v_s,a1_out.get(anchor), changed);
      } else {
        a1_out.set(anchor,a_stmt_assigned_in.get(v_s), changed);
        a_stmt_assigned_out.set(v_s,a1_out.get(anchor), changed);
      }
    }
  }
```