### PR TITLE
Skip evaluation of orphan nodes in dynamic evaluation

### DIFF
--- a/aps2scala/dyn-impl.cc
+++ b/aps2scala/dyn-impl.cc
@@ -92,7 +92,7 @@ static void dump_context_open(void *c, ostream& os) {
 	{
 	  Type ty = infer_pattern_type(matcher_pat(top_level_match_m(decl)));
 	  os << indent() << "for (anchor <- " << as_val(ty)
-	     << ".nodes) anchor match {\n";
+	     << ".nodes; if anchor.isRooted) anchor match {\n";
 	  ++nesting_level;
 	}
 	return;


### PR DESCRIPTION
`Cool.y` creates orphan nodes when generating the AST, but these nodes cause problems during dynamic evaluation. We can either fix `Cool.y` or avoid the problem in dynamic evaluation code generation