### PR TITLE
Refactor isRooted method to use loops instead of recursion

### DIFF
--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -122,7 +122,13 @@ abstract class Node(t : C_PHYLUM[_ <: Node]) extends Value(t)
     }
     this
   }
-  def isRooted : Boolean = (parent != null) && parent.isRooted;
+  def isRooted : Boolean = {
+    var p: Node = this
+    while (p.parent != null) p = p.parent
+    // If p == this, we have no parent and no override, therefore not rooted.
+    // Otherwise p.isRooted calls to (e.g. T_Program.isRooted) which returns true.
+    if (p == this) false else p.isRooted
+  }
 }
 
 class Nodes[T_Result <: Node] extends ArrayBuffer[T_Result] {


### PR DESCRIPTION
We use `isRooted` in dynamic evaluation now, see this PR: https://github.com/boyland/aps/pull/167

However, if AST is very large, we get to StackOverflow, and we have no choice but to add `-Xss8m` to increase the stack size. But we can do the same with loops.

`isRooted` is set in tree code, for example

```scala
  abstract class T_Operation(t : I_PHYLUM[T_Operation]) extends Node(t) {}

  abstract class T_Program(t : I_PHYLUM[T_Program]) extends Node(t) {
    override def isRooted : Boolean = true; // here
  }
```