### PR TITLE
Modify recompute to use set instead of manual assignment

### DIFF
--- a/base/scala/aps-impl.scala
+++ b/base/scala/aps-impl.scala
@@ -522,8 +522,7 @@ trait CircularEvaluation[V_P, V_T] extends Evaluation[V_P,V_T] {
   
   def recompute() : Unit = {
     val newValue = compute;
-    check(newValue);
-    value = newValue;
+    set(newValue);
   }
 }
 


### PR DESCRIPTION
In the dynamic evaluation of Farrow-UBD, I was getting this `non-monotonic` error. I think the problem shows itself when we have circular AND collection attribute like `decls_defs` in Farrow-UBD.aps

```
Exception in thread "main" Evaluation$CyclicAttributeException: cyclic attribute: non-monotonic decls_append(decls_append(decls_append(#,#),decl_assign(Symbol(ak),#)),decl_assign(Symbol(an),expr_apply(#,#,#))).decls_defs
	at CircularEvaluation.check(aps-impl.scala:519)
	at CircularEvaluation.check$(aps-impl.scala:515)
	at M_FARROW_UBD$E_decls_defs.check(farrow-ubd.scala:158)
	at CircularEvaluation.recompute(aps-impl.scala:531)
	at CircularEvaluation.recompute$(aps-impl.scala:529)
	at M_FARROW_UBD$E_decls_defs.recompute(farrow-ubd.scala:158)
	at CircularEvaluation.evaluateCycle(aps-impl.scala:500)
	at CircularEvaluation.evaluateCycle$(aps-impl.scala:492)
	at M_FARROW_UBD$E_decls_defs.evaluateCycle(farrow-ubd.scala:158)
	at Evaluation.doEvaluate(aps-impl.scala:252)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_defs.CollectionEvaluation$$super$get(farrow-ubd.scala:158)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_defs.get(farrow-ubd.scala:158)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_defs$1(farrow-ubd.scala:168)
	at M_FARROW_UBD.$anonfun$c_decls_defs$6(farrow-ubd.scala:389)
	at M_FARROW_UBD.$anonfun$c_decls_defs$6$adapted(farrow-ubd.scala:387)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decls_defs(farrow-ubd.scala:387)
	at M_FARROW_UBD$E_decls_defs.compute(farrow-ubd.scala:163)
	at M_FARROW_UBD$E_decls_defs.compute(farrow-ubd.scala:158)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_defs.CollectionEvaluation$$super$get(farrow-ubd.scala:158)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_defs.get(farrow-ubd.scala:158)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_defs$1(farrow-ubd.scala:168)
	at M_FARROW_UBD.$anonfun$c_decls_env$6(farrow-ubd.scala:428)
	at M_FARROW_UBD.$anonfun$c_decls_env$6$adapted(farrow-ubd.scala:425)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decls_env(farrow-ubd.scala:425)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:175)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:170)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_env.CollectionEvaluation$$super$get(farrow-ubd.scala:170)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_env.get(farrow-ubd.scala:170)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_env$1(farrow-ubd.scala:180)
	at M_FARROW_UBD.$anonfun$c_decls_env$4(farrow-ubd.scala:421)
	at M_FARROW_UBD.$anonfun$c_decls_env$4$adapted(farrow-ubd.scala:419)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decls_env(farrow-ubd.scala:419)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:175)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:170)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_env.CollectionEvaluation$$super$get(farrow-ubd.scala:170)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_env.get(farrow-ubd.scala:170)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_env$1(farrow-ubd.scala:180)
	at M_FARROW_UBD.$anonfun$c_decls_env$4(farrow-ubd.scala:421)
	at M_FARROW_UBD.$anonfun$c_decls_env$4$adapted(farrow-ubd.scala:419)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decls_env(farrow-ubd.scala:419)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:175)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:170)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_env.CollectionEvaluation$$super$get(farrow-ubd.scala:170)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_env.get(farrow-ubd.scala:170)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_env$1(farrow-ubd.scala:180)
	at M_FARROW_UBD.$anonfun$c_decls_env$6(farrow-ubd.scala:427)
	at M_FARROW_UBD.$anonfun$c_decls_env$6$adapted(farrow-ubd.scala:425)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decls_env(farrow-ubd.scala:425)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:175)
	at M_FARROW_UBD$E_decls_env.compute(farrow-ubd.scala:170)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decls_env.CollectionEvaluation$$super$get(farrow-ubd.scala:170)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decls_env.get(farrow-ubd.scala:170)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decls_env$1(farrow-ubd.scala:180)
	at M_FARROW_UBD.$anonfun$c_decl_env$2(farrow-ubd.scala:357)
	at M_FARROW_UBD.$anonfun$c_decl_env$2$adapted(farrow-ubd.scala:355)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decl_env(farrow-ubd.scala:355)
	at M_FARROW_UBD$E_decl_env.compute(farrow-ubd.scala:143)
	at M_FARROW_UBD$E_decl_env.compute(farrow-ubd.scala:138)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decl_env.CollectionEvaluation$$super$get(farrow-ubd.scala:138)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decl_env.get(farrow-ubd.scala:138)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_decl_env$1(farrow-ubd.scala:148)
	at M_FARROW_UBD.$anonfun$c_expr_env$2(farrow-ubd.scala:502)
	at M_FARROW_UBD.$anonfun$c_expr_env$2$adapted(farrow-ubd.scala:500)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_expr_env(farrow-ubd.scala:500)
	at M_FARROW_UBD$E_expr_env.compute(farrow-ubd.scala:205)
	at M_FARROW_UBD$E_expr_env.compute(farrow-ubd.scala:200)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_expr_env.CollectionEvaluation$$super$get(farrow-ubd.scala:200)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_expr_env.get(farrow-ubd.scala:200)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_expr_env$1(farrow-ubd.scala:210)
	at M_FARROW_UBD.$anonfun$c_term_env$2(farrow-ubd.scala:551)
	at M_FARROW_UBD.$anonfun$c_term_env$2$adapted(farrow-ubd.scala:549)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_term_env(farrow-ubd.scala:549)
	at M_FARROW_UBD$E_term_env.compute(farrow-ubd.scala:235)
	at M_FARROW_UBD$E_term_env.compute(farrow-ubd.scala:230)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_term_env.CollectionEvaluation$$super$get(farrow-ubd.scala:230)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_term_env.get(farrow-ubd.scala:230)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_term_env$1(farrow-ubd.scala:240)
	at M_FARROW_UBD.c1_variable_value(farrow-ubd.scala:307)
	at M_FARROW_UBD$E1_variable_value.compute(farrow-ubd.scala:291)
	at M_FARROW_UBD$E1_variable_value.compute(farrow-ubd.scala:288)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.c_term_val(farrow-ubd.scala:535)
	at M_FARROW_UBD$E_term_val.compute(farrow-ubd.scala:223)
	at M_FARROW_UBD$E_term_val.compute(farrow-ubd.scala:220)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_term_val$1(farrow-ubd.scala:228)
	at M_FARROW_UBD.c_expr_val(farrow-ubd.scala:486)
	at M_FARROW_UBD$E_expr_val.compute(farrow-ubd.scala:193)
	at M_FARROW_UBD$E_expr_val.compute(farrow-ubd.scala:190)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at Attribute.get(aps-impl.scala:355)
	at M_FARROW_UBD.$anonfun$v_expr_val$1(farrow-ubd.scala:198)
	at M_FARROW_UBD.$anonfun$c_decl_pair$2(farrow-ubd.scala:347)
	at M_FARROW_UBD.$anonfun$c_decl_pair$2$adapted(farrow-ubd.scala:344)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:905)
	at M_FARROW_UBD.c_decl_pair(farrow-ubd.scala:344)
	at M_FARROW_UBD$E_decl_pair.compute(farrow-ubd.scala:131)
	at M_FARROW_UBD$E_decl_pair.compute(farrow-ubd.scala:126)
	at Evaluation.doEvaluate(aps-impl.scala:249)
	at Evaluation.get(aps-impl.scala:265)
	at M_FARROW_UBD$E_decl_pair.CollectionEvaluation$$super$get(farrow-ubd.scala:126)
	at CollectionEvaluation.get(aps-impl.scala:381)
	at CollectionEvaluation.get$(aps-impl.scala:379)
	at M_FARROW_UBD$E_decl_pair.get(farrow-ubd.scala:126)
	at Attribute.get(aps-impl.scala:355)
	at Attribute.$anonfun$finish$1(aps-impl.scala:327)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at Attribute.finish(aps-impl.scala:326)
	at M_FARROW_UBD.finish(farrow-ubd.scala:711)
	at FarrowUbdDriver$.delayedEndpoint$FarrowUbdDriver$1(FarrowUbdDriver.scala:25)
	at FarrowUbdDriver$delayedInit$body.apply(FarrowUbdDriver.scala:1)
	at scala.Function0.apply$mcV$sp(Function0.scala:42)
	at scala.Function0.apply$mcV$sp$(Function0.scala:42)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
	at scala.App.$anonfun$main$1(App.scala:98)
	at scala.App.$anonfun$main$1$adapted(App.scala:98)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:935)
	at scala.App.main(App.scala:98)
	at scala.App.main$(App.scala:96)
	at FarrowUbdDriver$.main(FarrowUbdDriver.scala:1)
	at FarrowUbdDriver.main(FarrowUbdDriver.scala)

Process finished with exit code 1
```

Example randomly generated program where the problem shows itself
[farrow-ubd-program.zip](https://github.com/user-attachments/files/27466567/farrow-ubd-program.zip)
