### PR TITLE
Proposal: Refactor Makefile to support dynamic/static evaluators

### DIFF
--- a/examples/scala/Makefile
+++ b/examples/scala/Makefile
@@ -8,11 +8,23 @@ SCALACFLAGS= ${SCALAFLAGS}
 APS2SCALA = ${APSTOP}/bin/aps2scala
 APS2SCALAFLAGS = -p ..:${APSTOP}/base -G
 
+EVALUATOR ?= DYNAMIC
+
+ifeq (${EVALUATOR},STATIC)
+IMPL_SUFFIX = .static.scala
+else
+IMPL_SUFFIX = .scala
+endif
+
 SCALAGEN = simple.scala classic-binding.scala tiny.scala broad-fiber-cycle.scala \
 	test-coll.scala test-use-coll.scala test-cycle.scala use-global.scala \
 	grammar.scala first.scala follow.scala nullable.scala	\
 	farrow-lv-tree.scala farrow-lv.static.scala \
-	farrow-ubd-tree.scala farrow-ubd.static.scala
+	farrow-ubd-tree.scala farrow-ubd.static.scala farrow-ubd-fiber.static.scala \
+	broad-fiber-cycle.static.scala classic-binding.static.scala \
+	grammar.scala first.static.scala follow.static.scala nullable.static.scala \
+	nested-cycles.static.scala \
+	test-coll.static.scala test-use-coll.static.scala test-cycle.static.scala use-global.static.scala
 
 MISCGEN = nested-cycles.scala SimpleParser.scala SimpleScanner.scala \
 	GrammarTokens.scala SimpleTokens.scala GrammarScanner.scala GrammarParser.scala \
@@ -45,6 +57,11 @@ phony_explicit:
 
 %.static.scala : ../%.aps ${APS2SCALA}
 	${APS2SCALA} ${APS2SCALAFLAGS} -S -C $*
+	mv $*.scala $@
+
+%.synth.scala : ../%.aps ${APS2SCALA}
+	${APS2SCALA} ${APS2SCALAFLAGS} -F $*
+	mv $*.scala $@
 
 %.scala : ../%.aps ${APS2SCALA}
 	${APS2SCALA} ${APS2SCALAFLAGS} $*
@@ -78,10 +95,10 @@ FarrowUbdParserBase.class : FarrowUbdParserBase.scala FarrowUbd_implicit.class
 FarrowUbdTokens.class : FarrowUbdTokens.scala
 	${SCALAC} ${SCALACFLAGS} $<
 
-FarrowUbd_implicit.class : farrow-ubd-tree.scala farrow-ubd.scala
+FarrowUbd_implicit.class : farrow-ubd-tree.scala farrow-ubd${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $^
 
-FarrowUbdFiber_implicit.class : farrow-ubd-tree.scala farrow-ubd-fiber.scala
+FarrowUbdFiber_implicit.class : farrow-ubd-tree.scala farrow-ubd-fiber${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $^
 
 FarrowUbdDriver.class : FarrowUbd_implicit.class FarrowUbdParser.class
@@ -116,7 +133,7 @@ FarrowLvParserBase.class : FarrowLvParserBase.scala FarrowLv_implicit.class
 FarrowLvTokens.class : FarrowLvTokens.scala
 	${SCALAC} ${SCALACFLAGS} $<
 
-FarrowLv_implicit.class : farrow-lv-tree.scala farrow-lv.scala
+FarrowLv_implicit.class : farrow-lv-tree.scala farrow-lv${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $^
 
 FarrowLvDriver.class : FarrowLv_implicit.class FarrowLvParser.class
@@ -174,8 +191,8 @@ SimpleParserBase.class : SimpleParserBase.scala simple_implicit.class
 SimpleTokens.class : SimpleTokens.scala
 	${SCALAC} ${SCALACFLAGS} $<
 
-nested-cycles.class: nested-cycles.static.scala simple_implicit.class
-	${SCALAC} ${SCALACFLAGS} nested-cycles.scala
+nested-cycles.class: nested-cycles${IMPL_SUFFIX} simple_implicit.class
+	${SCALAC} ${SCALACFLAGS} $<
 
 .PHONY: nested_cycles_implicit.class
 nested_cycles_implicit.class : nested-cycles.class simple_implicit.class ;
@@ -183,7 +200,7 @@ nested_cycles_implicit.class : nested-cycles.class simple_implicit.class ;
 NestedCyclesDriver.class: nested_cycles_implicit.class SimpleParser.class
 	${SCALAC} ${SCALACFLAGS} nested-cycles-driver.scala
 
-classic_binding_implicit.class : classic-binding.scala
+classic_binding_implicit.class : classic-binding${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $<
 
 Classic.class : classic-driver.scala SimpleParser.class
@@ -192,10 +209,10 @@ Classic.class : classic-driver.scala SimpleParser.class
 Classic.class   classic_binding_implicit.class : simple_implicit.class
 Classic.class : classic_binding_implicit.class
 
-test_coll_implicit.class : test-coll.scala tiny_implicit.class
+test_coll_implicit.class : test-coll${IMPL_SUFFIX} tiny_implicit.class
 	${SCALAC} ${SCALACFLAGS} $<
 
-test_use_coll_implicit.class : test-use-coll.scala
+test_use_coll_implicit.class : test-use-coll${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $<
 
 TestCollDriver.class : test_coll_implicit.class test-coll-driver.scala
@@ -204,13 +221,13 @@ TestCollDriver.class : test_coll_implicit.class test-coll-driver.scala
 TestUseCollDriver.class : test_use_coll_implicit.class test-use-coll-driver.scala tiny_implicit.class
 	${SCALAC} ${SCALACFLAGS}  test-use-coll-driver.scala
 
-test_cycle_implicit.class : test-cycle.scala
+test_cycle_implicit.class : test-cycle${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $<
 
 TestCycleDriver.class : test_cycle_implicit.class test-cycle-driver.scala
 	${SCALAC} ${SCALACFLAGS}  test-cycle-driver.scala
 
-grammar_implicit.class : grammar.scala first.scala follow.scala nullable.scala
+grammar_implicit.class : grammar.scala first${IMPL_SUFFIX} follow${IMPL_SUFFIX} nullable${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $^
 
 GrammarDriver.class : grammar_implicit.class GrammarParser.class
@@ -219,15 +236,15 @@ GrammarDriver.class : grammar_implicit.class GrammarParser.class
 TinyParser.class : tiny-parser.handcode.scala tiny_implicit.class
 	${SCALAC} ${SCALACFLAGS} tiny-parser.handcode.scala
 
-use_global_implicit.class : use-global.scala tiny_implicit.class
-	${SCALAC} ${SCALACFLAGS} use-global.scala
+use_global_implicit.class : use-global${IMPL_SUFFIX} tiny_implicit.class
+	${SCALAC} ${SCALACFLAGS} $<
 
 UseGlobal.class : use_global_implicit.class TinyParser.class
 UseGlobal.class : use-global-driver.scala
 	${SCALAC} ${SCALACFLAGS} $<
 
 broad_fiber_cycle_implicit.class : tiny_implicit.class
-broad_fiber_cycle_implicit.class : broad-fiber-cycle.scala
+broad_fiber_cycle_implicit.class : broad-fiber-cycle${IMPL_SUFFIX}
 	${SCALAC} ${SCALACFLAGS} $<
 
 BroadFiberCycleDriver.class : broad_fiber_cycle_implicit.class tiny_implicit.class

--- a/examples/scala/README
+++ b/examples/scala/README
@@ -1,4 +1,10 @@
-make ARGS="farrow-lv.program" FarrowLvDriver.run
-make ARGS="farrow-ubd.program" FarrowUbdDriver.run
-make ARGS="farrow-ubd.program" FarrowUbdFiberDriver.run
-make ARGS="grammar.cfg" GrammarDriver.run
+# The EVALUATOR variable controls which evaluator is used (default: DYNAMIC)
+make EVALUATOR=STATIC ARGS="farrow-lv.program" FarrowLvDriver.run
+make EVALUATOR=STATIC ARGS="farrow-ubd.program" FarrowUbdDriver.run
+make EVALUATOR=STATIC ARGS="farrow-ubd.program" FarrowUbdFiberDriver.run
+make EVALUATOR=STATIC ARGS="grammar.cfg" GrammarDriver.run
+make EVALUATOR=STATIC BroadFiberCycleDriver.run
+make EVALUATOR=STATIC Classic.run
+make EVALUATOR=STATIC TestCollDriver.run
+make EVALUATOR=STATIC TestUseCollDriver.run
+make EVALUATOR=STATIC NestedCyclesDriver.run


### PR DESCRIPTION
Right now the type of evaluator for each of these test files is hard-coded in the Makefile. I was thinking we can make the evaluator a variable. For example

```shell
# Dynamic by default
make ARGS="farrow-lv.program" FarrowLvDriver.run
make EVALUATOR=STATIC ARGS="farrow-lv.program" FarrowLvDriver.run
make EVALUATOR=SYNTH ARGS="farrow-lv.program" FarrowLvDriver.run
```