### PR TITLE
Change Block.block_env to circular attribute

### DIFF
--- a/examples/nested-ubd.aps
+++ b/examples/nested-ubd.aps
@@ -25,7 +25,7 @@ module NESTED_UBD[T :: var NESTED_UBD_TREE[]] extends T begin
   pragma inherited(decls_env);
   pragma synthesized(decls_defs, decls_errs);
 
-  attribute Block.block_env : DeclPairLattice;
+  circular attribute Block.block_env : DeclPairLattice;
   attribute Block.block_errs : Messages;
   pragma inherited (block_env);
   pragma synthesized (block_errs);


### PR DESCRIPTION
Make block_env in `nested-ubd.aps` circular, otherwise getting circular attribute error.

```
amir@pop-os:~/workspace/synth-functions-pr-final/examples/scala$ make EVALUATOR=DYNAMIC ARGS="/home/amir/workspace/random-farrow-ubd-program/10.program" NestedUbdDriver.run
../../bin/aps2scala -p ..:../../base -G nested-ubd-tree
../../bin/aps2scala -p ..:../../base -G nested-ubd
scalac -cp .:../../lib/aps-library.jar nested-ubd-tree.scala nested-ubd.scala
warning: 19 deprecations (since 2.13.3); re-run with -deprecation for details
1 warning
scalac -cp .:../../lib/aps-library.jar NestedUbdParserBase.scala
scalac -cp .:../../lib/aps-library.jar NestedUbdParser.scala
warning: 24 deprecations (since 2.13.3); re-run with -deprecation for details
1 warning
scalac -cp .:../../lib/aps-library.jar nested-ubd-driver.scala
warning: 1 feature warning; re-run with -feature for details
1 warning
scala -cp .:../../lib/aps-library.jar NestedUbdDriver /home/amir/workspace/random-farrow-ubd-program/10.program
Evaluation$CyclicAttributeException: cyclic attribute: scope(decls_add(decls_append(#,#),scope(#))).block_env
        at Evaluation.setInCycle(aps-impl.scala:240)
        at CircularEvaluation.$anonfun$markPending$1(aps-impl.scala:488)
        at CircularEvaluation.$anonfun$markPending$1$adapted(aps-impl.scala:481)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
        at Evaluation$Stack.foreach(aps-impl.scala:203)
        at CircularEvaluation.markPending(aps-impl.scala:481)
        at CircularEvaluation.markPending$(aps-impl.scala:479)
        at M_NESTED_UBD$E_decls_env.markPending(nested-ubd.scala:174)
        at CircularEvaluation.detectedCycle(aps-impl.scala:475)
        at CircularEvaluation.detectedCycle$(aps-impl.scala:468)
        at M_NESTED_UBD$E_decls_env.detectedCycle(nested-ubd.scala:174)
        at Evaluation.doEvaluate(aps-impl.scala:245)
        at Evaluation.get(aps-impl.scala:265)
        at M_NESTED_UBD$E_decls_env.CollectionEvaluation$$super$get(nested-ubd.scala:174)
        at CollectionEvaluation.get(aps-impl.scala:381)
        at CollectionEvaluation.get$(aps-impl.scala:379)
        at M_NESTED_UBD$E_decls_env.get(nested-ubd.scala:174)
        at Attribute.get(aps-impl.scala:355)
        at M_NESTED_UBD.$anonfun$v_decls_env$1(nested-ubd.scala:184)
        at M_NESTED_UBD.c_block_env(nested-ubd.scala:490)
        at M_NESTED_UBD$E_block_env.compute(nested-ubd.scala:195)
        at M_NESTED_UBD$E_block_env.compute(nested-ubd.scala:194)
        at Evaluation.doEvaluate(aps-impl.scala:249)
        at Evaluation.get(aps-impl.scala:265)
        at Attribute.get(aps-impl.scala:355)
        at M_NESTED_UBD.$anonfun$v_block_env$1(nested-ubd.scala:200)
        at M_NESTED_UBD.$anonfun$c_decls_env$2(nested-ubd.scala:429)
        at M_NESTED_UBD.$anonfun$c_decls_env$2$adapted(nested-ubd.scala:427)
```