### PR TITLE
Some static type checking improvements

### DIFF
--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -2358,9 +2358,20 @@ static void init_analysis_state(STATE *s, Declaration module) {
       case KEYattribute_decl:
 	if (!ATTR_DECL_IS_SYN(decl) && !ATTR_DECL_IS_INH(decl) &&
 	    !FIELD_DECL_P(decl)) {
-	  aps_error(decl,"%s not declared either synthesized or inherited",
-		    decl_name(decl));
-	  Declaration_info(decl)->decl_flags |= ATTR_DECL_SYN_FLAG;
+	  Direction dir = attribute_decl_direction(decl);
+	  if (direction_is_input(dir)) {
+	    aps_warning(decl, "%s not declared inherited; assuming inherited",
+			decl_name(decl));
+	    Declaration_info(decl)->decl_flags |= ATTR_DECL_INH_FLAG;
+	  } else if (direction_is_circular(dir) || direction_is_collection(dir)) {
+	    aps_warning(decl, "%s not declared synthesized; assuming synthesized",
+			decl_name(decl));
+	    Declaration_info(decl)->decl_flags |= ATTR_DECL_SYN_FLAG;
+	  } else {
+	    aps_error(decl, "%s not declared either synthesized or inherited",
+		      decl_name(decl));
+	    Declaration_info(decl)->decl_flags |= ATTR_DECL_SYN_FLAG;
+	  }
 	}
 	{ Type ftype = attribute_decl_type(decl);
 	  Declaration formal = first_Declaration(function_type_formals(ftype));

--- a/analyze/aps-dnc.c
+++ b/analyze/aps-dnc.c
@@ -2360,11 +2360,11 @@ static void init_analysis_state(STATE *s, Declaration module) {
 	    !FIELD_DECL_P(decl)) {
 	  Direction dir = attribute_decl_direction(decl);
 	  if (direction_is_input(dir)) {
-	    aps_warning(decl, "%s not declared inherited; assuming inherited",
+	    aps_error(decl, "%s not declared inherited; assuming inherited",
 			decl_name(decl));
 	    Declaration_info(decl)->decl_flags |= ATTR_DECL_INH_FLAG;
 	  } else if (direction_is_circular(dir) || direction_is_collection(dir)) {
-	    aps_warning(decl, "%s not declared synthesized; assuming synthesized",
+	    aps_error(decl, "%s not declared synthesized; assuming synthesized",
 			decl_name(decl));
 	    Declaration_info(decl)->decl_flags |= ATTR_DECL_SYN_FLAG;
 	  } else {

--- a/codegen/static-scc-impl.cc
+++ b/codegen/static-scc-impl.cc
@@ -1054,8 +1054,10 @@ static void dump_visit_functions(PHY_GRAPH* pg, output_streams& oss)
   int num_cons = aug_graphs.size();
 
   if (num_cons == 0) {
-    fatal_error("no top-level-match match for phylum %s",
+    aps_error(pg->phylum,
+              "no top-level-match match for phylum %s",
                 decl_name(pg->phylum));
+    return;
   }
 
   // The match clauses may be in a different order

--- a/examples/test-cycle.aps
+++ b/examples/test-cycle.aps
@@ -6,10 +6,6 @@ module TEST_CYCLE[T :: var TINY[]] extends T begin
 
   var circular collection leaves : IntegerLattice;
   circular attribute Wood.partial : IntegerLattice;
-  pragma synthesized(partial);
-
-  match root(?) begin
-  end;
 
   match ?l=leaf(?x) begin
     l.partial := (leaves \ x) \/ {x+1} ;

--- a/examples/test-cycle.aps
+++ b/examples/test-cycle.aps
@@ -6,6 +6,10 @@ module TEST_CYCLE[T :: var TINY[]] extends T begin
 
   var circular collection leaves : IntegerLattice;
   circular attribute Wood.partial : IntegerLattice;
+  pragma synthesized(partial);
+
+  match root(?) begin
+  end;
 
   match ?l=leaf(?x) begin
     l.partial := (leaves \ x) \/ {x+1} ;


### PR DESCRIPTION
If we are missing the following in `aps-cycle.aps`

```
  pragma synthesized(partial);

  match root(?) begin
  end;
```

We get a warning
```
amir@pop-os:~/workspace/aps-static-isue/examples$ make test-cycle.scc.sched | more
../bin/apssched -C -DCOTo -p .:../base test-cycle
test-cycle.aps:8:Warning: partial not declared synthesized; assuming synthesized
```