### PR TITLE
Farrow-UBD.aps fixing monotonicity in decls_append

### DIFF
--- a/examples/farrow-ubd.aps
+++ b/examples/farrow-ubd.aps
@@ -66,14 +66,13 @@ module FARROW_UBD[T :: var FARROW_UBD_TREE[]] extends T begin
   match ?self:Declarations=decls_append(?ds: Declarations, ?d: Declaration) begin
     ds.decls_env := self.decls_env;
     d.decl_env := self.decls_env;
+    self.decls_defs := DeclPairLattice$join(ds.decls_defs, d.decl_pair);
 
     case DeclPairLattice$select(ds.decls_defs, d.decl_name) begin
       match DeclPairLattice$table_entry(?,?value) begin
         self.decls_errs := { "identifier " ++ symbol_name(d.decl_name) ++ " is multiply defined" } \/ ds.decls_errs \/ d.decl_errs;
-        self.decls_defs := ds.decls_defs;
       end;
       else
-        self.decls_defs := DeclPairLattice$join(ds.decls_defs, d.decl_pair);
         self.decls_errs := ds.decls_errs \/ d.decl_errs;
     end;
   end;


### PR DESCRIPTION
Same change as [`0d03a6e7f7643a6e3dbb692b3cdbdf5b701c6cda`](https://github.com/boyland/aps/commit/0d03a6e7f7643a6e3dbb692b3cdbdf5b701c6cda) but for Farrow-UBD