### PR TITLE
Fixing simple-snc.aps

### DIFF
--- a/examples/simple-snc.aps
+++ b/examples/simple-snc.aps
@@ -52,11 +52,16 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
   end;
 
   match ?s:Stmt=block_stmt(?b:Block) begin
+    s.total := 0;
   end;
   
   match ?e:Expr=strconstant(?:String) begin
+    e.s1 := 0;
+    e.s2 := 0;
   end;
 
   match ?e:Expr=variable(?id:String) begin
+    e.s1 := 0;
+    e.s2 := 0;
   end;
 end;


### PR DESCRIPTION
Making sure all the attributes of `simple-snc.aps` are assigned, no undefined attributes