### PR TITLE
Simple-SNC driver + more interesting aps code

### DIFF
--- a/examples/scala/Makefile
+++ b/examples/scala/Makefile
@@ -30,7 +30,7 @@ AST_TREE_SCALAGEN = simple.scala tiny.scala grammar.scala \
 EVALUATOR_EXAMPLES = classic-binding first follow nullable test-coll \
 	test-use-coll test-cycle test-fields use-global broad-fiber-cycle \
 	below-fiber-cycle below-single-fiber-cycle local-fiber-cycle nested-cycles \
-	farrow-lv farrow-ubd farrow-ubd-fiber nested-ubd nested-ubd-fiber
+	farrow-lv farrow-ubd farrow-ubd-fiber nested-ubd nested-ubd-fiber simple-snc
 SCALAGEN = ${AST_TREE_SCALAGEN} \
 	$(foreach example,${EVALUATOR_EXAMPLES},$(example).scala $(example).static.scala)
 
@@ -64,6 +64,7 @@ all : ${OUT}/below_fiber_cycle_implicit.class ${OUT}/BelowFiberCycleDriver.class
 all : ${OUT}/below_single_fiber_cycle_implicit.class ${OUT}/BelowSingleFiberCycleDriver.class
 all : ${OUT}/local_fiber_cycle_implicit.class ${OUT}/LocalFiberCycleDriver.class
 all : ${OUT}/test_fields_implicit.class ${OUT}/TestFieldsDriver.class
+all : ${OUT}/simple_snc_implicit.class ${OUT}/SimpleSncDriver.class
 
 .PHONY: run
 
@@ -349,6 +350,15 @@ ${OUT}/local_fiber_cycle_implicit.class : local-fiber-cycle${IMPL_SUFFIX}
 ${OUT}/LocalFiberCycleDriver.class : ${OUT}/local_fiber_cycle_implicit.class ${OUT}/tiny_implicit.class ${OUT}/TinyParser.class
 ${OUT}/LocalFiberCycleDriver.class : local-fiber-cycle-driver.scala
 	${SCALAC} ${SCALACFLAGS} $<
+
+${OUT}/simple-snc.class: simple-snc${IMPL_SUFFIX} ${OUT}/simple_implicit.class
+	${SCALAC} ${SCALACFLAGS} $<
+
+.PHONY: ${OUT}/simple_snc_implicit.class
+${OUT}/simple_snc_implicit.class : ${OUT}/simple-snc.class ${OUT}/simple_implicit.class ;
+
+${OUT}/SimpleSncDriver.class: ${OUT}/simple_snc_implicit.class ${OUT}/SimpleParser.class
+	${SCALAC} ${SCALACFLAGS} simple-snc-driver.scala
 
 .PHONY: %.run
 

--- a/examples/scala/README
+++ b/examples/scala/README
@@ -16,3 +16,4 @@ make EVALUATOR=STATIC NestedCyclesDriver.run
 make EVALUATOR=STATIC ARGS="nested-ubd.program" NestedUbdDriver.run
 make EVALUATOR=STATIC ARGS="nested-ubd.program" NestedUbdFiberDriver.run
 make EVALUATOR=STATIC ARGS="tiny.program" TestFieldsDriver.run
+make EVALUATOR=DYNAMIC ARGS="simple.program" SimpleSncDriver.run

--- a/examples/scala/compare-evaluators.sh
+++ b/examples/scala/compare-evaluators.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-EVALUATORS=(DYNAMIC STATIC)
+DEFAULT_EVALUATORS="DYNAMIC,STATIC"
 
 extract_results() {
   sed -n '/^Results:$/,$p'
@@ -27,8 +27,9 @@ run_with_evaluator() {
 
 run_driver() {
   local driver="$1"
-  shift
-  local args="$*"
+  local args="$2"
+  local -a evals
+  IFS=',' read -ra evals <<< "$3"
   local pass=true
   local build_failed=false
   local tmpdir
@@ -37,7 +38,7 @@ run_driver() {
   echo "--- $driver ${args:+(${args})} ---"
 
   local built_evaluators=()
-  for eval in "${EVALUATORS[@]}"; do
+  for eval in "${evals[@]}"; do
     echo "  running $eval ..."
     if ! run_with_evaluator "$eval" "$driver" "$args" "$tmpdir/$eval"; then
       echo "  FAIL: $eval build failed"
@@ -59,9 +60,13 @@ run_driver() {
 
   local n=${#built_evaluators[@]}
   if [ $n -lt 2 ]; then
-    echo "  FAIL: fewer than 2 evaluators built successfully"
+    if [ $n -eq 1 ]; then
+      echo "  OK: ${built_evaluators[0]} ran successfully"
+    else
+      echo "  FAIL: no evaluators ran successfully"
+    fi
     rm -rf "$tmpdir"
-    return 1
+    return $(( n == 0 ))
   fi
 
   for ((i=0; i<n-1; i++)); do
@@ -84,35 +89,38 @@ run_driver() {
 
 if [ $# -gt 0 ]; then
   driver="$1"
-  shift
-  run_driver "$driver" "$@"
+  args="${2:-}"
+  evals="${3:-$DEFAULT_EVALUATORS}"
+  run_driver "$driver" "$args" "$evals"
   exit $?
 fi
 
 TESTS=(
-  "BroadFiberCycleDriver|tiny.program"
-  "BelowFiberCycleDriver|tiny.program"
-  "BelowSingleFiberCycleDriver|tiny.program"
-  "LocalFiberCycleDriver|tiny.program"
-  "TestCollDriver|tiny.program"
-  "TestUseCollDriver|tiny.program"
-  "TestCycleDriver|tiny.program"
-  "UseGlobal|tiny.program"
-  "FarrowUbdDriver|farrow-ubd.program"
-  "FarrowUbdFiberDriver|farrow-ubd.program"
-  "NestedUbdDriver|nested-ubd.program"
-  "NestedUbdFiberDriver|nested-ubd.program"
-  "TestFieldsDriver|tiny.program"
+  "BroadFiberCycleDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "BelowFiberCycleDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "BelowSingleFiberCycleDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "LocalFiberCycleDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "TestCollDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "TestUseCollDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "TestCycleDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "UseGlobal|tiny.program|$DEFAULT_EVALUATORS"
+  "FarrowUbdDriver|farrow-ubd.program|$DEFAULT_EVALUATORS"
+  "FarrowUbdFiberDriver|farrow-ubd.program|$DEFAULT_EVALUATORS"
+  "NestedUbdDriver|nested-ubd.program|$DEFAULT_EVALUATORS"
+  "NestedUbdFiberDriver|nested-ubd.program|$DEFAULT_EVALUATORS"
+  "TestFieldsDriver|tiny.program|$DEFAULT_EVALUATORS"
+  "SimpleSncDriver|simple.program|DYNAMIC"
 )
 
 failures=0
 total=0
 
 for test in "${TESTS[@]}"; do
-  IFS="|" read -r driver args <<< "$test"
+  IFS="|" read -r driver args evals <<< "$test"
+  evals="${evals:-$DEFAULT_EVALUATORS}"
   total=$((total + 1))
   return_code=0
-  run_driver "$driver" "$args" || return_code=$?
+  run_driver "$driver" "$args" "$evals" || return_code=$?
   if [ $return_code -eq 1 ]; then
     failures=$((failures + 1))
   fi

--- a/examples/scala/simple-snc-driver.scala
+++ b/examples/scala/simple-snc-driver.scala
@@ -1,0 +1,36 @@
+object SimpleSncDriver extends App {
+  var simple_tree : M_SIMPLE = null;
+  var p: Any = _;
+  if (args.length == 0) {
+    simple_tree = new M_SIMPLE("Simple");
+    val t_simple = simple_tree.t_Result;
+    val ds = t_simple.v_xcons_decls(t_simple.v_no_decls(),
+                t_simple.v_decl("x",t_simple.v_integer_type()));
+    val s =	t_simple.v_assign_stmt(t_simple.v_intconstant(3),
+                t_simple.v_intconstant(5));
+    val ss = t_simple.v_xcons_stmts(t_simple.v_no_stmts(),s);
+    p = t_simple.v_program(t_simple.v_block(ds,ss));
+  } else {
+    val ss = new SimpleScanner(new java.io.FileReader(args(0)));
+    val sp = new SimpleParser();
+    sp.reset(ss, args(0));
+    if (!sp.yyparse()) {
+      println("Errors found.\n");
+      System.exit(1);
+    }
+    simple_tree = sp.getTree();
+    p = simple_tree.t_Program;
+  }
+
+  val m_simple = simple_tree;
+  val m_snc = new M_SIMPLE_SNC[m_simple.T_Result]("SimpleSNC", m_simple.t_Result);
+  val t_snc = m_snc.t_Result;
+
+  if (args.contains("--debug")) Debug.activate();
+
+  m_simple.finish();
+  m_snc.finish();
+
+  println("Results:");
+  println("program_total is " + t_snc.v_program_total(t_snc.t_Program.nodes(0)));
+}

--- a/examples/scala/simple.program
+++ b/examples/scala/simple.program
@@ -1,0 +1,19 @@
+{
+  int x;
+  int y;
+  string s;
+  int z;
+  x = 3;
+  y = 5;
+  x = y;
+  z = 10;
+  {
+    int a;
+    int b;
+    a = 7;
+    b = a;
+    a = 42;
+  }
+  y = z;
+  s = "hello";
+}

--- a/examples/simple-snc.aps
+++ b/examples/simple-snc.aps
@@ -15,16 +15,16 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
   pragma synthesized(expr_s1, expr_s2, block_total, stmt_total, stmts_total, program_total);
 
   match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
-    e1.expr_i1 := 0;
+    e1.expr_i1 := 1;
     e1.expr_i2 := e1.expr_s1;
-    e2.expr_i2 := 0;
+    e2.expr_i2 := 2;
     e2.expr_i1 := e2.expr_s2;
     s.stmt_total := e1.expr_s2 + e2.expr_s1;
   end;
   
   match ?e:Expr=intconstant(?i:Integer) begin
-    e.expr_s1 := e.expr_i1;
-    e.expr_s2 := e.expr_i2;
+    e.expr_s1 := e.expr_i1 + i + 1;
+    e.expr_s2 := e.expr_i2 + i + 2;
   end;
 
   match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
@@ -59,7 +59,7 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
   end;
 
   match ?s:Stmt=block_stmt(?b:Block) begin
-    s.stmt_total := 0;
+    s.stmt_total := b.block_total;
   end;
   
   match ?e:Expr=strconstant(?:String) begin

--- a/examples/simple-snc.aps
+++ b/examples/simple-snc.aps
@@ -1,30 +1,34 @@
 with "simple";
 -- Simple example of SNC
 module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
-  attribute Expr.i1 : Integer;
-  attribute Expr.i2 : Integer;
-  attribute Expr.s1 : Integer;
-  attribute Expr.s2 : Integer;
+  attribute Expr.expr_i1 : Integer;
+  attribute Expr.expr_i2 : Integer;
+  attribute Expr.expr_s1 : Integer;
+  attribute Expr.expr_s2 : Integer;
   
-  attribute Stmt.total : Integer;
+  attribute Block.block_total : Integer;
+  attribute Stmt.stmt_total : Integer;
+  attribute Stmts.stmts_total : Integer;
+  attribute Program.program_total : Integer;
 
-  pragma inherited(i1,i2);
-  pragma synthesized(s1,s2,total);
+  pragma inherited(expr_i1, expr_i2);
+  pragma synthesized(expr_s1, expr_s2, block_total, stmt_total, stmts_total, program_total);
 
   match ?s:Stmt=assign_stmt(?e1:Expr,?e2:Expr) begin
-    e1.i1 := 0;
-    e1.i2 := e1.s1;
-    e2.i2 := 0;
-    e2.i1 := e2.s2;
-    s.total := e1.s2 + e2.s1;
+    e1.expr_i1 := 0;
+    e1.expr_i2 := e1.expr_s1;
+    e2.expr_i2 := 0;
+    e2.expr_i1 := e2.expr_s2;
+    s.stmt_total := e1.expr_s2 + e2.expr_s1;
   end;
   
   match ?e:Expr=intconstant(?i:Integer) begin
-    e.s1 := e.i1;
-    e.s2 := e.i2;
+    e.expr_s1 := e.expr_i1;
+    e.expr_s2 := e.expr_i2;
   end;
 
   match ?b:Block=block(?ds:Decls,?ss:Stmts) begin
+    b.block_total := ss.stmts_total;
   end;
 
   match ?ds:Decls=no_decls() begin
@@ -37,6 +41,7 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
   end;
 
   match ?p:Program=program(?b:Block) begin
+    p.program_total := b.block_total;
   end;
 
   match ?t:Type=integer_type() begin
@@ -45,23 +50,25 @@ module SIMPLE_SNC[T :: var SIMPLE[]] extends T begin
   match ?t:Type=string_type() begin
   end;
 
-  match ?:Stmts=no_stmts() begin
+  match ?ss:Stmts=no_stmts() begin
+    ss.stmts_total := 0;
   end;
   
   match ?ss0:Stmts=xcons_stmts(?ss1:Stmts,?s:Stmt) begin
+    ss0.stmts_total := ss1.stmts_total + s.stmt_total;
   end;
 
   match ?s:Stmt=block_stmt(?b:Block) begin
-    s.total := 0;
+    s.stmt_total := 0;
   end;
   
   match ?e:Expr=strconstant(?:String) begin
-    e.s1 := 0;
-    e.s2 := 0;
+    e.expr_s1 := 0;
+    e.expr_s2 := 0;
   end;
 
   match ?e:Expr=variable(?id:String) begin
-    e.s1 := 0;
-    e.s2 := 0;
+    e.expr_s1 := 0;
+    e.expr_s2 := 0;
   end;
 end;


### PR DESCRIPTION
- modified `compare-evaluators.sh` to take type of evaluators as parameter. This is needed once we merge synth because we want it to compare dynamic vs. synth only, not static
- made simple-snc more interesting by not using 0 everywhere and also bubbling up the total all the way to program for the compare to work
- tiny driver for simple-snc + `simple.program`